### PR TITLE
feat: sync CrewAI template with production oncall-crewai

### DIFF
--- a/examples/templates/crewai-agent/content-agent/requirements.txt
+++ b/examples/templates/crewai-agent/content-agent/requirements.txt
@@ -1,20 +1,9 @@
 # ==============================================================================
 # Python Dependencies
 # ==============================================================================
-# Pin major versions for reproducibility. Run `pip install -r requirements.txt`
-# to install all dependencies.
-#
-# CORE STACK:
-# - crewai: Multi-agent AI framework (agents, tasks, crews, flows)
-# - fastapi + uvicorn: High-performance async web framework + ASGI server
-# - a2a-sdk: Google's Agent-to-Agent protocol SDK
-# - pydantic: Data validation and settings management
-# - anthropic: Anthropic API client (used by CrewAI via LiteLLM)
-#
 # IMPORTANT: crewai is pinned to 1.6.x because 1.10+ adds LanceDB as the
 # default memory backend. LanceDB's Rust binaries require AVX2 CPU
-# instructions, which older CPUs (e.g. Intel E5-2670 Sandy Bridge) lack,
-# causing SIGILL (exit code 132) on Flow() instantiation.
+# instructions, which older CPUs lack, causing SIGILL (exit code 132).
 # ==============================================================================
 
 # --- AI / Agent Framework ---
@@ -26,8 +15,6 @@ fastapi>=0.115.0,<1.0.0
 uvicorn>=0.34.0,<1.0.0
 
 # --- A2A Protocol ---
-# Pinned to 0.3.24 — the v0.3.x API uses A2AStarletteApplication,
-# RequestContext, InMemoryTaskStore (different from v0.2.x)
 a2a-sdk==0.3.24
 
 # --- LLM Provider ---
@@ -36,9 +23,25 @@ anthropic>=0.42.0,<1.0.0
 # --- Data Validation ---
 pydantic>=2.10.0,<3.0.0
 
+# --- Environment ---
+python-dotenv>=1.0.0,<2.0.0
+
+{%- if values.enableAuth %}
+
+# --- Auth ---
+PyJWT>=2.11.0,<3.0.0
+bcrypt>=5.0.0,<6.0.0
+{%- endif %}
+
+{%- if values.enableCopilotKit %}
+
+# --- CopilotKit / AG-UI ---
+ag-ui-protocol>=0.1.13,<1.0.0
+{%- endif %}
+
 {%- if values.enableKnowledge %}
+
 # --- Knowledge / RAG ---
-# pdfplumber is required for PDF knowledge source ingestion
 pdfplumber>=0.11.0,<1.0.0
 {%- endif %}
 

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/agents.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/agents.py
@@ -70,7 +70,7 @@ def create_sub_agent_delegate() -> Agent:
                 location="header",     # Send API key in HTTP header
                 name="X-API-Key",      # Header name
             ),
-            timeout=120,               # Seconds to wait for sub-agent response
+            timeout=300,               # Seconds to wait for sub-agent response
             max_turns=10,              # Max back-and-forth exchanges
             trust_remote_completion_status=True,  # Accept sub-agent's "done" signal
         ),

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/auth.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/auth.py
@@ -1,0 +1,83 @@
+{%- if values.enableAuth %}
+{% raw %}
+"""Authentication utilities for JWT and API key auth.
+
+Provides JWT token creation/verification and a unified FastAPI
+dependency that accepts either JWT Bearer tokens or API keys.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from fastapi import HTTPException, Request
+
+from shared.config import API_KEYS, JWT_EXPIRY_HOURS, JWT_SECRET
+from shared.logging_config import setup_logging
+
+logger = setup_logging("auth")
+
+
+@dataclass
+class AuthInfo:
+    """Result of authentication — identifies the caller."""
+
+    user_id: str | None  # None for API_KEY auth (service-to-service)
+    username: str | None  # None for API_KEY auth
+
+
+def create_jwt(user_id: str, username: str) -> str:
+    """Create a signed JWT token for a user."""
+    payload = {
+        "sub": user_id,
+        "username": username,
+        "iat": datetime.now(timezone.utc),
+        "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def verify_jwt(token: str) -> dict:
+    """Verify and decode a JWT token."""
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+        return payload
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def verify_auth(request: Request) -> AuthInfo:
+    """Unified auth dependency: accepts JWT Bearer token OR API key."""
+    auth_header = request.headers.get("Authorization", "")
+    api_key_header = request.headers.get("X-API-Key", "")
+
+    api_key_valid = bool(api_key_header and API_KEYS and api_key_header in API_KEYS)
+
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        if API_KEYS and token in API_KEYS:
+            return AuthInfo(user_id=None, username=None)
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+            return AuthInfo(
+                user_id=payload.get("sub"),
+                username=payload.get("username"),
+            )
+        except jwt.InvalidTokenError:
+            if api_key_valid:
+                return AuthInfo(user_id=None, username=None)
+
+    if api_key_valid:
+        return AuthInfo(user_id=None, username=None)
+
+    if api_key_header:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    if not API_KEYS:
+        return AuthInfo(user_id=None, username=None)  # Dev mode
+
+    raise HTTPException(status_code=401, detail="Authentication required")
+{% endraw %}
+{%- endif %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/copilotkit_endpoint.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/copilotkit_endpoint.py
@@ -1,0 +1,172 @@
+{%- if values.enableCopilotKit %}
+{% raw %}
+"""AG-UI SSE endpoint for CopilotKit integration.
+
+Provides a /copilotkit POST endpoint that accepts AG-UI RunAgentInput,
+routes queries through the classify/delegate pipeline,
+and streams back AG-UI events for CopilotKit to consume.
+"""
+
+import asyncio
+import re
+import uuid
+
+from ag_ui.core import (
+    EventType,
+    RunAgentInput,
+    RunFinishedEvent,
+    RunStartedEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+)
+from ag_ui.encoder import EventEncoder
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+
+from shared.logging_config import setup_logging
+
+logger = setup_logging("copilotkit-endpoint")
+
+encoder = EventEncoder()
+
+_TOOL_CALL_XML_RE = re.compile(
+    r"<function_calls>.*?</function_calls>",
+    re.DOTALL,
+)
+
+
+def _clean_agent_response(text: str) -> str:
+    """Strip raw XML tool-call blocks that CrewAI may include in output."""
+    cleaned = _TOOL_CALL_XML_RE.sub("", text)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _extract_latest_user_message(input_data: RunAgentInput) -> str:
+    """Extract the latest user message from AG-UI RunAgentInput."""
+    if input_data.messages:
+        for msg in reversed(input_data.messages):
+            if hasattr(msg, "role") and str(msg.role) == "user":
+                if hasattr(msg, "content"):
+                    content = msg.content
+                    if isinstance(content, str):
+                        return content
+                    elif isinstance(content, list):
+                        text_parts = []
+                        for part in content:
+                            if isinstance(part, str):
+                                text_parts.append(part)
+                            elif hasattr(part, "text"):
+                                text_parts.append(part.text)
+                        if text_parts:
+                            return " ".join(text_parts)
+    return "Hello"
+
+
+async def copilotkit_handler(request: Request, auth=None):
+    """Handle AG-UI requests from CopilotKit frontend."""
+    body = await request.json()
+    input_data = RunAgentInput(**body)
+
+    thread_id = input_data.thread_id or str(uuid.uuid4())
+    run_id = input_data.run_id or str(uuid.uuid4())
+    message_id = str(uuid.uuid4())
+
+    user_message = _extract_latest_user_message(input_data)
+
+    user_id = auth.user_id if auth and hasattr(auth, "user_id") and auth.user_id else ""
+
+    logger.info(f"CopilotKit request: thread={thread_id}, query={user_message[:80]}...")
+
+    async def event_stream():
+        yield encoder.encode(
+            RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+        )
+
+        yield encoder.encode(
+            TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=message_id,
+                role="assistant",
+            )
+        )
+
+        yield encoder.encode(
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta="Processing query...\n\n",
+            )
+        )
+
+        try:
+            from orchestrator.flow import OrchestratorFlow
+
+            # Build context from previous conversation turns if session manager available
+            query_with_context = user_message
+            session_mgr = getattr(request.app.state, "session_manager", None)
+            if session_mgr:
+                context = session_mgr.build_conversation_context(thread_id)
+                if context:
+                    query_with_context = context + user_message
+
+            flow = OrchestratorFlow()
+            flow.state.query = query_with_context
+            result = await asyncio.to_thread(flow.kickoff)
+            result_text = _clean_agent_response(str(result))
+        except Exception as e:
+            logger.error(f"CopilotKit flow error: {e}", exc_info=True)
+            result_text = f"Error processing query: {e}"
+
+        # Persist the exchange if session manager available
+        try:
+            session_mgr = getattr(request.app.state, "session_manager", None)
+            if session_mgr:
+                session_mgr.append_messages(
+                    session_id=thread_id,
+                    user_msg=user_message,
+                    assistant_msg=result_text,
+                    user_id=user_id or "",
+                )
+        except Exception as e:
+            logger.warning(f"Failed to persist session {thread_id}: {e}")
+
+        yield encoder.encode(
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta=result_text,
+            )
+        )
+
+        yield encoder.encode(
+            TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=message_id,
+            )
+        )
+
+        yield encoder.encode(
+            RunFinishedEvent(
+                type=EventType.RUN_FINISHED,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+        )
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+{% endraw %}
+{%- endif %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/flow.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/flow.py
@@ -1,145 +1,110 @@
 # ==============================================================================
 # Orchestrator Flow — Query Classification & Routing
 # ==============================================================================
-#
-# WHAT IS A CREWAI FLOW?
-# A Flow is a deterministic state machine that orchestrates agent execution.
-# Unlike a Crew (which runs tasks sequentially or hierarchically), a Flow
-# gives you explicit control over the execution order via decorators:
-#
-#   @start()   — marks the first method to run
-#   @router()  — returns a route name that determines which method runs next
-#   @listen()  — runs when a specific route is selected
-#
-# WHY USE A FLOW INSTEAD OF A CREW?
-# The orchestrator's job is routing, not reasoning. A Flow gives us:
-# 1. Deterministic execution (keyword match → route → delegate)
-# 2. Zero LLM calls for routing (no wasted tokens on classification)
-# 3. Clear state management (OrchestratorFlowState tracks the full lifecycle)
-# 4. Easy to extend (add new @listen methods for new sub-agents)
-#
-# EXECUTION SEQUENCE:
-#   classify() → route_query() → handle_sub_agent() OR handle_no_match()
-# ==============================================================================
 {% raw %}
 import concurrent.futures
+import uuid
 
 from crewai import Crew, Task
 from crewai.flow.flow import Flow, start, router, listen
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from orchestrator.agents import create_sub_agent_delegate
-from orchestrator.prompts import ROUTING_KEYWORDS, NO_MATCH_RESPONSE
+from orchestrator.prompts import ROUTING_KEYWORDS
+from shared.config import CREWAI_VERBOSE, SINGLE_AGENT_BYPASS
 from shared.logging_config import setup_logging
 
 logger = setup_logging("orchestrator.flow")
 
+# Try to import @persist for flow resilience; degrade gracefully if unavailable
+try:
+    from crewai.flow.persistence import persist as _persist
+    _HAS_PERSIST = True
+except ImportError:
+    _HAS_PERSIST = False
+
 
 class OrchestratorFlowState(BaseModel):
+    """State that persists across all steps in the flow."""
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    query: str = ""
+    route: str = ""
+    result: str = ""
+
+
+def classify_query(query: str) -> str:
+    """Classify a query into a route based on keyword matching.
+
+    Returns "sub_agent" if keywords match or SINGLE_AGENT_BYPASS is enabled.
     """
-    State that persists across all steps in the flow.
+    if SINGLE_AGENT_BYPASS:
+        return "sub_agent"
 
-    Each @start/@router/@listen method can read and write to this state.
-    The state is created fresh for each flow.kickoff() call.
-    """
-    query: str = ""               # The user's original query
-    route: str = ""               # Which route was selected: "sub_agent" or "no_match"
-    result: str = ""              # The final response to return to the user
+    query_lower = query.lower()
+    matches = [kw for kw in ROUTING_KEYWORDS if kw in query_lower]
+    if matches:
+        logger.info(f"Keyword match: {matches[:5]} → routing to sub-agent")
+    else:
+        logger.info("No keyword match → defaulting to sub-agent")
+    return "sub_agent"
 
 
-class OrchestratorFlow(Flow[OrchestratorFlowState]):
-    """
-    Routes incoming queries to the appropriate sub-agent.
+def _build_flow_class():
+    class _OrchestratorFlow(Flow[OrchestratorFlowState]):
+        """Routes incoming queries to the appropriate sub-agent."""
 
-    The flow uses keyword matching (not LLM) for fast, deterministic routing.
-    """
+        initial_state = OrchestratorFlowState
 
-    @start()
-    def classify(self) -> str:
-        """
-        Step 1: Classify the query by checking for keyword matches.
+        @start()
+        def classify(self) -> str:
+            query = self.state.query
+            route = classify_query(query)
+            self.state.route = route
+            logger.info(f"Query classified: route={route}, query={query[:80]}...")
+            return route
 
-        This is the first method that runs (marked with @start).
-        It reads the query from state and checks if any routing keywords appear in it.
+        @router(classify)
+        def route_query(self) -> str:
+            return self.state.route or "sub_agent"
 
-        Returns:
-            A classification label used by the router.
-        """
-        query_lower = self.state.query.lower()
+        @listen("sub_agent")
+        def handle_sub_agent(self) -> str:
+            logger.info(f"Delegating to sub-agent: {self.state.query[:100]}")
+            try:
+                delegate = create_sub_agent_delegate()
+                task = Task(
+                    description=self.state.query,
+                    expected_output="A complete and helpful response to the user's query.",
+                    agent=delegate,
+                )
+                crew = Crew(
+                    agents=[delegate],
+                    tasks=[task],
+                    verbose=CREWAI_VERBOSE,
+                    output_log_file="/tmp/crewai-logs.txt",
+                )
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    result = pool.submit(crew.kickoff).result()
+                raw = result.raw if hasattr(result, "raw") else str(result)
+                self.state.result = raw.replace("\\n", "\n")
+            except Exception as e:
+                logger.error(f"Sub-agent delegation failed: {e}")
+                self.state.result = f"Agent error: {e}"
+            return self.state.result
 
-        # Count how many keywords match — more matches = higher confidence
-        matches = [kw for kw in ROUTING_KEYWORDS if kw in query_lower]
+    return _OrchestratorFlow
 
-        if matches:
-            logger.info(f"Keyword match: {matches[:5]} → routing to sub-agent")
-            self.state.route = "sub_agent"
-            return "sub_agent"
-        else:
-            logger.info("No keyword match → returning fallback response")
-            self.state.route = "no_match"
-            return "no_match"
 
-    @router(classify)
-    def route_query(self) -> str:
-        """
-        Step 2: Route based on the classification result.
-
-        Reads state.route (set by classify) and returns the route name,
-        which determines which @listen method runs next.
-
-        Returns:
-            Route name: "sub_agent" or "no_match"
-        """
-        return self.state.route or "no_match"
-
-    @listen("sub_agent")
-    def handle_sub_agent(self) -> str:
-        """
-        Step 3a: Delegate the query to the sub-agent via A2A.
-
-        This runs when route_query() returns "sub_agent".
-        It creates a delegate agent and runs a single-task Crew to invoke it.
-
-        IMPORTANT: crew.kickoff() is run in a ThreadPoolExecutor because
-        flow.kickoff() already owns the event loop (via asyncio.run()),
-        and crew.kickoff() also calls asyncio.run() internally. Running
-        in a separate thread gives it its own event loop.
-        """
-        logger.info(f"Delegating to sub-agent: {self.state.query[:100]}")
-
-        try:
-            # Create the A2A delegate agent
-            delegate = create_sub_agent_delegate()
-
-            # Create a task for the delegate — it will forward to the sub-agent via A2A
-            task = Task(
-                description=self.state.query,
-                expected_output="A complete and helpful response to the user's query.",
-                agent=delegate,
-            )
-
-            # Run the crew (single agent, single task)
-            crew = Crew(agents=[delegate], tasks=[task], verbose=True)
-
-            # Run in a separate thread to avoid nested asyncio.run() conflict
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                result = pool.submit(crew.kickoff).result()
-
-            self.state.result = result.raw if hasattr(result, "raw") else str(result)
-        except Exception as e:
-            logger.error(f"Sub-agent delegation failed: {e}")
-            self.state.result = f"Agent error: {e}"
-
-        return self.state.result
-
-    @listen("no_match")
-    def handle_no_match(self) -> str:
-        """
-        Step 3b: Return a helpful fallback when no keywords match.
-
-        This runs when route_query() returns "no_match".
-        Instead of failing, it tells the user what topics the agent can help with.
-        """
-        self.state.result = NO_MATCH_RESPONSE
-        return self.state.result
+# Apply @persist if available
+_FlowClass = _build_flow_class()
+if _HAS_PERSIST:
+    try:
+        OrchestratorFlow = _persist()(_FlowClass)
+        logger.info("Flow persistence enabled")
+    except Exception as e:
+        logger.warning(f"Failed to enable flow persistence: {e}")
+        OrchestratorFlow = _FlowClass
+else:
+    logger.info("Flow persistence not available")
+    OrchestratorFlow = _FlowClass
 {% endraw %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
@@ -2,147 +2,439 @@
 # Orchestrator — FastAPI Application
 # ==============================================================================
 #
-# WHAT THIS FILE DOES:
-# This is the main entry point for the orchestrator service. It creates a
-# FastAPI web server with three key endpoints:
-#
-# 1. GET  /health   — Health check (used by K8s liveness/readiness probes)
-# 2. POST /invoke   — Send a query to be routed to the appropriate sub-agent
-# 3. GET  /info     — Returns metadata about the orchestrator and its agents
-#
-# HOW REQUESTS FLOW:
-#   Client → POST /invoke {"query": "..."} → OrchestratorFlow.kickoff()
-#   → keyword classification → A2A call to sub-agent → response back to client
+# Entry point for the orchestrator service. Creates a FastAPI web server with:
+# - GET  /health   — Health check (K8s probes)
+# - POST /invoke   — Route query to sub-agent
+# - GET  /info     — Orchestrator metadata
+# - Auth, session, and CopilotKit endpoints (conditional)
+# - A2A server for agent-to-agent discovery
 #
 # RUNNING THIS SERVICE:
 #   uvicorn orchestrator.main:app --host 0.0.0.0 --port 8000
 # ==============================================================================
 {% raw %}
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+import asyncio
 import os
+import uuid
+from contextlib import asynccontextmanager
 
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    Message,
+    Role,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from shared.a2a_utils import extract_user_input
 from shared.config import PROJECT_NAME, ORCHESTRATOR_PORT, API_KEYS
 from shared.logging_config import setup_logging
+{% endraw %}
+{%- if values.enableAuth %}
+{% raw %}
+from orchestrator.auth import AuthInfo, create_jwt, verify_auth
+{% endraw %}
+{%- endif %}
+{%- if values.enableCopilotKit %}
+{% raw %}
+try:
+    from orchestrator.copilotkit_endpoint import copilotkit_handler
+    _HAS_AG_UI = True
+except ImportError:
+    _HAS_AG_UI = False
+{% endraw %}
+{%- endif %}
+{%- if values.enableSessions %}
+{% raw %}
+from orchestrator.session_manager import SessionManager
+{% endraw %}
+{%- endif %}
+{%- if values.enableAuth %}
+{% raw %}
+from orchestrator.user_manager import UserManager
+{% endraw %}
+{%- endif %}
+{% raw %}
 
 logger = setup_logging("orchestrator")
 
 
 # --- REQUEST/RESPONSE MODELS ---
-# Pydantic models define the shape of API requests and responses.
-# FastAPI auto-generates OpenAPI docs from these (visit /docs in the browser).
 
 class InvokeRequest(BaseModel):
     """Request body for the /invoke endpoint."""
-    query: str  # The user's question or command
+    query: str
+{% endraw %}
+{%- if values.enableSessions %}
+{% raw %}
+    context_id: str = ""
+{% endraw %}
+{%- endif %}
+{% raw %}
 
 
 class InvokeResponse(BaseModel):
     """Response body from the /invoke endpoint."""
-    result: str  # The agent's response text
-    route: str   # Which sub-agent handled the query (for debugging)
+    result: str
+    route: str
+{% endraw %}
+{%- if values.enableSessions %}
+{% raw %}
+    context_id: str = ""
+{% endraw %}
+{%- endif %}
+{%- if values.enableAuth %}
+{% raw %}
 
 
-# --- APPLICATION FACTORY ---
-# Using a function to create the app allows for easier testing
-# (you can create a fresh app instance for each test).
+class AuthRequest(BaseModel):
+    username: str
+    password: str
 
-def create_app() -> FastAPI:
-    """Create and configure the FastAPI application."""
-    application = FastAPI(
-        title=f"{PROJECT_NAME} Orchestrator",
-        description="Routes queries to CrewAI sub-agents via A2A protocol.",
+
+class AuthResponse(BaseModel):
+    token: str
+    user_id: str
+    username: str
+{% endraw %}
+{%- endif %}
+{% raw %}
+
+
+# --- A2A Executor ---
+
+class OrchestratorExecutor(AgentExecutor):
+    """A2A executor that runs the OrchestratorFlow."""
+
+    async def execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        task_id = context.task_id
+        context_id = context.context_id
+
+        try:
+            user_input = extract_user_input(context.message)
+            logger.info(f"A2A execute: task_id={task_id}, query={user_input[:80]}...")
+
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=task_id,
+                    context_id=context_id,
+                    final=False,
+                    status=TaskStatus(
+                        state=TaskState.working,
+                        message=Message(
+                            role=Role.agent,
+                            message_id=str(uuid.uuid4()),
+                            parts=[TextPart(text="Processing query...")],
+                        ),
+                    ),
+                )
+            )
+
+            from orchestrator.flow import OrchestratorFlow
+            flow = OrchestratorFlow()
+            flow.state.query = user_input
+            result = await asyncio.to_thread(flow.kickoff)
+
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=task_id,
+                    context_id=context_id,
+                    final=True,
+                    status=TaskStatus(
+                        state=TaskState.completed,
+                        message=Message(
+                            role=Role.agent,
+                            message_id=str(uuid.uuid4()),
+                            parts=[TextPart(text=str(result))],
+                        ),
+                    ),
+                )
+            )
+
+        except Exception as e:
+            logger.error(f"Orchestrator executor error: {e}", exc_info=True)
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=task_id,
+                    context_id=context_id,
+                    final=True,
+                    status=TaskStatus(
+                        state=TaskState.failed,
+                        message=Message(
+                            role=Role.agent,
+                            message_id=str(uuid.uuid4()),
+                            parts=[TextPart(text=f"Orchestrator error: {e}")],
+                        ),
+                    ),
+                )
+            )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise NotImplementedError("Orchestrator does not support cancellation")
+
+
+# --- App factory ---
+
+def _build_agent_card() -> AgentCard:
+    host = os.getenv("ORCHESTRATOR_HOST", "0.0.0.0")
+    port = int(os.getenv("ORCHESTRATOR_PORT", str(ORCHESTRATOR_PORT)))
+    url = os.getenv("ORCHESTRATOR_URL", f"http://{host}:{port}")
+
+    return AgentCard(
+        name="{% endraw %}${{ values.name }}{% raw %} Orchestrator",
+        description="Routes queries to specialized sub-agents via A2A protocol.",
+        url=url,
         version="1.0.0",
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[
+            AgentSkill(
+                id="route-query",
+                name="Route Query",
+                description="Classify and route a query to the appropriate sub-agent.",
+                tags=["routing", "orchestration"],
+            ),
+        ],
     )
 
-    # CORS (Cross-Origin Resource Sharing) middleware.
-    # This is required if a browser-based frontend calls this API.
-    # In production, restrict origins to your actual frontend domain.
+
+def create_app() -> FastAPI:
+    """Create the orchestrator FastAPI application."""
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+{% endraw %}
+{%- if values.enableAuth %}
+{% raw %}
+        app.state.user_manager = UserManager()
+{% endraw %}
+{%- endif %}
+{%- if values.enableSessions %}
+{% raw %}
+        app.state.session_manager = SessionManager()
+        app.state.session_manager.start_cleanup_task()
+{% endraw %}
+{%- endif %}
+{% raw %}
+        logger.info("Orchestrator started")
+        yield
+{% endraw %}
+{%- if values.enableSessions %}
+{% raw %}
+        app.state.session_manager.stop_cleanup_task()
+{% endraw %}
+{%- endif %}
+{% raw %}
+        logger.info("Orchestrator stopped")
+
+    fastapi_app = FastAPI(
+        title="{% endraw %}${{ values.name }}{% raw %} Orchestrator",
+        version="1.0.0",
+        description="Routes queries to CrewAI sub-agents via A2A protocol.",
+        lifespan=lifespan,
+    )
+
     cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
-    application.add_middleware(
+    fastapi_app.add_middleware(
         CORSMiddleware,
-        allow_origins=cors_origins,
+        allow_origins=[o.strip() for o in cors_origins if o.strip()],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
 
-    return application
+    @fastapi_app.get("/health")
+    async def health():
+        return JSONResponse({"status": "healthy", "service": "{% endraw %}${{ values.name }}{% raw %}"})
+
+    @fastapi_app.get("/info")
+    async def service_info():
+        from orchestrator.prompts import ROUTING_KEYWORDS
+        from shared.config import SUB_AGENT_URL
+        return {
+            "service": PROJECT_NAME,
+            "role": "orchestrator",
+            "copilotkit": {% endraw %}{{ "true" if values.enableCopilotKit else "false" }}{% raw %},
+            "sub_agents": [
+                {
+                    "name": "{% endraw %}${{ values.subAgentName }}{% raw %}",
+                    "url": SUB_AGENT_URL,
+                    "keywords": ROUTING_KEYWORDS,
+                }
+            ],
+        }
+{% endraw %}
+{%- if values.enableAuth %}
+{% raw %}
+
+    # --- Auth endpoints ---
+
+    @fastapi_app.post("/auth/register", response_model=AuthResponse)
+    async def register(req: AuthRequest, request: Request):
+        um: UserManager = request.app.state.user_manager
+        try:
+            user = um.create_user(req.username, req.password)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        token = create_jwt(user.user_id, user.username)
+        return AuthResponse(token=token, user_id=user.user_id, username=user.username)
+
+    @fastapi_app.post("/auth/login", response_model=AuthResponse)
+    async def login(req: AuthRequest, request: Request):
+        um: UserManager = request.app.state.user_manager
+        user = um.authenticate(req.username, req.password)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid username or password")
+        token = create_jwt(user.user_id, user.username)
+        return AuthResponse(token=token, user_id=user.user_id, username=user.username)
+
+    @fastapi_app.get("/auth/me")
+    async def auth_me(auth: AuthInfo = Depends(verify_auth)):
+        if not auth.user_id:
+            raise HTTPException(status_code=401, detail="JWT authentication required")
+        return JSONResponse({"user_id": auth.user_id, "username": auth.username})
+{% endraw %}
+{%- endif %}
+{% raw %}
+
+    # --- Query endpoint ---
+
+    @fastapi_app.post("/invoke", response_model=InvokeResponse)
+    def invoke(request: InvokeRequest{% endraw %}{%- if values.enableAuth %}{% raw %}, auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+        logger.info(f"Received query: {request.query[:100]}")
+        try:
+            from orchestrator.flow import OrchestratorFlow
+{% endraw %}
+{%- if values.enableSessions %}
+{% raw %}
+            context_id = request.context_id or str(uuid.uuid4())
+            query_text = request.query
+            if request.context_id:
+                try:
+                    mgr: SessionManager = fastapi_app.state.session_manager
+                    context = mgr.build_conversation_context(context_id)
+                    if context:
+                        query_text = context + request.query
+                except Exception as e:
+                    logger.warning(f"Failed to load session context: {e}")
+{% endraw %}
+{%- else %}
+{% raw %}
+            query_text = request.query
+{% endraw %}
+{%- endif %}
+{% raw %}
+
+            flow = OrchestratorFlow()
+            flow.state.query = query_text
+            result = flow.kickoff()
+            result_text = str(result)
+{% endraw %}
+{%- if values.enableSessions %}
+{% raw %}
+
+            if request.context_id:
+                try:
+                    mgr: SessionManager = fastapi_app.state.session_manager
+                    mgr.append_messages(
+                        session_id=context_id,
+                        user_msg=request.query,
+                        assistant_msg=result_text,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to persist session {context_id}: {e}")
+
+            return InvokeResponse(result=result_text, route=flow.state.route, context_id=context_id)
+{% endraw %}
+{%- else %}
+{% raw %}
+            return InvokeResponse(result=result_text, route=flow.state.route)
+{% endraw %}
+{%- endif %}
+{% raw %}
+        except Exception as e:
+            logger.error(f"Error processing query: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+{% endraw %}
+{%- if values.enableCopilotKit %}
+{% raw %}
+
+    # --- CopilotKit AG-UI endpoint ---
+    if _HAS_AG_UI:
+        @fastapi_app.post("/copilotkit")
+        async def copilotkit(request: Request{% endraw %}{%- if values.enableAuth %}{% raw %}, auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+            return await copilotkit_handler(request{% endraw %}{%- if values.enableAuth %}{% raw %}, auth{% endraw %}{%- endif %}{% raw %})
+{% endraw %}
+{%- endif %}
+{%- if values.enableSessions %}
+{% raw %}
+
+    # --- Session endpoints ---
+
+    @fastapi_app.post("/sessions/{session_id}", status_code=201)
+    async def init_session(session_id: str{% endraw %}{%- if values.enableAuth %}{% raw %}, auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+        mgr: SessionManager = fastapi_app.state.session_manager
+        session = mgr.get_or_create_session(session_id)
+        return JSONResponse(session.to_summary(), status_code=201)
+
+    @fastapi_app.get("/sessions")
+    async def list_sessions({% endraw %}{%- if values.enableAuth %}{% raw %}auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+        mgr: SessionManager = fastapi_app.state.session_manager
+        return JSONResponse(mgr.list_sessions({% endraw %}{%- if values.enableAuth %}{% raw %}user_id=auth.user_id{% endraw %}{%- endif %}{% raw %}))
+
+    @fastapi_app.get("/sessions/{session_id}")
+    async def get_session(session_id: str{% endraw %}{%- if values.enableAuth %}{% raw %}, auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+        mgr: SessionManager = fastapi_app.state.session_manager
+        session = mgr.get_session(session_id{% endraw %}{%- if values.enableAuth %}{% raw %}, user_id=auth.user_id{% endraw %}{%- endif %}{% raw %})
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return JSONResponse(session.to_dict())
+
+    @fastapi_app.delete("/sessions/{session_id}", status_code=204)
+    async def delete_session(session_id: str{% endraw %}{%- if values.enableAuth %}{% raw %}, auth: AuthInfo = Depends(verify_auth){% endraw %}{%- endif %}{% raw %}):
+        mgr: SessionManager = fastapi_app.state.session_manager
+        if not mgr.delete_session(session_id{% endraw %}{%- if values.enableAuth %}{% raw %}, user_id=auth.user_id{% endraw %}{%- endif %}{% raw %}):
+            raise HTTPException(status_code=404, detail="Session not found")
+{% endraw %}
+{%- endif %}
+{% raw %}
+
+    # --- A2A server ---
+    agent_card = _build_agent_card()
+    executor = OrchestratorExecutor()
+    task_store = InMemoryTaskStore()
+    handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=task_store,
+    )
+    a2a_app = A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=handler,
+    )
+    fastapi_app.mount("/", a2a_app.build())
+
+    logger.info(f"Orchestrator ready: {agent_card.url}")
+    return fastapi_app
 
 
 app = create_app()
-
-
-# --- ENDPOINTS ---
-
-@app.get("/health")
-async def health_check():
-    """
-    Health check endpoint.
-
-    Kubernetes uses this for:
-    - livenessProbe: "Is the process alive?" (restarts pod if this fails)
-    - readinessProbe: "Is the service ready for traffic?" (removes from Service endpoints if this fails)
-
-    Returns a simple JSON object with service status.
-    """
-    return {"status": "healthy", "service": PROJECT_NAME}
-
-
-@app.get("/info")
-async def service_info():
-    """
-    Returns metadata about the orchestrator and its configured agents.
-    Useful for debugging and service discovery.
-    """
-    from orchestrator.prompts import ROUTING_KEYWORDS
-    from shared.config import SUB_AGENT_URL
-
-    return {
-        "service": PROJECT_NAME,
-        "role": "orchestrator",
-        "sub_agents": [
-            {
-                "name": "{% endraw %}${{ values.subAgentName }}{% raw %}",
-                "url": SUB_AGENT_URL,
-                "keywords": ROUTING_KEYWORDS,
-            }
-        ],
-    }
-
-
-# IMPORTANT: This endpoint is intentionally a sync `def` (not `async def`).
-# CrewAI's Flow.kickoff() internally calls asyncio.run(), which cannot be
-# nested inside an already-running event loop (uvicorn's). By making this
-# a sync function, FastAPI automatically runs it in a thread pool, giving
-# it its own event loop where asyncio.run() works correctly.
-@app.post("/invoke", response_model=InvokeResponse)
-def invoke(request: InvokeRequest):
-    """
-    Main query endpoint.
-
-    Receives a user query, runs it through the OrchestratorFlow (which
-    classifies the query and routes it to the appropriate sub-agent via A2A),
-    and returns the result.
-    """
-    logger.info(f"Received query: {request.query[:100]}")
-
-    try:
-        # Import here to avoid circular imports and allow lazy loading
-        from orchestrator.flow import OrchestratorFlow
-
-        # Create a new flow instance and execute it.
-        # CrewAI Flows maintain state across steps (classify → route → handle).
-        flow = OrchestratorFlow()
-        result = flow.kickoff(inputs={"query": request.query})
-
-        # The flow's final state contains the result and which route was taken
-        return InvokeResponse(
-            result=str(result),
-            route=flow.state.route,
-        )
-    except Exception as e:
-        logger.error(f"Error processing query: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
 {% endraw %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/prompts.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/prompts.py
@@ -1,41 +1,12 @@
 # ==============================================================================
 # Orchestrator Prompts & Routing Keywords
 # ==============================================================================
-#
-# HOW ROUTING WORKS:
-# Instead of using an LLM to classify queries (expensive, slow, non-deterministic),
-# we use simple keyword matching. This is the "80/20 rule" — keyword matching
-# handles 80% of routing correctly with zero latency and zero cost.
-#
-# The orchestrator checks if the user's query contains any of the keywords below.
-# If it does, the query is routed to the sub-agent. If not, the orchestrator
-# returns a helpful message explaining what it can help with.
-#
-# WHY NOT LLM-BASED ROUTING?
-# 1. Zero extra API calls (saves money and latency)
-# 2. Deterministic — same input always routes the same way
-# 3. Easy to debug — just check which keywords matched
-# 4. Easy to extend — just add more keywords to the list
-#
-# The keywords below were populated from your template parameters.
-# Add or remove keywords as you discover new routing patterns.
-# ==============================================================================
 {% raw %}
 # Keywords that trigger routing to the sub-agent.
 # These are matched case-insensitively against the user's query.
-# Populated from template parameter: routingKeywords
 ROUTING_KEYWORDS = [
     k.strip().lower()
     for k in "{% endraw %}${{ values.routingKeywords }}{% raw %}".split(",")
     if k.strip()
 ]
-
-# Fallback message when no keywords match.
-# This tells the user what the agent CAN help with, reducing confusion.
-NO_MATCH_RESPONSE = (
-    "I'm not sure how to help with that specific request. "
-    "I'm specialized in topics related to: "
-    f"{', '.join(ROUTING_KEYWORDS[:10])}. "
-    "Could you rephrase your question or ask about one of these topics?"
-)
 {% endraw %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/session_manager.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/session_manager.py
@@ -1,0 +1,355 @@
+{%- if values.enableSessions %}
+{% raw %}
+"""Session Manager for conversation persistence.
+
+SQLite-backed session storage with in-memory cache,
+TTL expiration, and background cleanup.
+"""
+
+import asyncio
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from shared.logging_config import setup_logging
+
+logger = setup_logging("session-manager")
+
+SESSION_DB_PATH = os.getenv("SESSION_DB_PATH", "/data/sessions.db")
+SESSION_TTL_HOURS = int(os.getenv("SESSION_TTL_HOURS", "0"))
+SESSION_MAX_TOTAL = int(os.getenv("SESSION_MAX_TOTAL", "500"))
+SESSION_CONTEXT_MAX_TURNS = int(os.getenv("SESSION_CONTEXT_MAX_TURNS", "5"))
+
+
+@dataclass
+class Session:
+    """A conversation session with message history."""
+
+    session_id: str
+    title: str
+    created_at: datetime
+    last_accessed: datetime
+    messages: list[dict] = field(default_factory=list)
+    user_id: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "title": self.title,
+            "created_at": self.created_at.isoformat(),
+            "last_accessed": self.last_accessed.isoformat(),
+            "messages": self.messages,
+            "message_count": len(self.messages),
+        }
+
+    def to_summary(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "title": self.title,
+            "created_at": self.created_at.isoformat(),
+            "last_accessed": self.last_accessed.isoformat(),
+            "message_count": len(self.messages),
+        }
+
+
+class SessionManager:
+    """Manages conversation sessions with SQLite persistence."""
+
+    def __init__(
+        self,
+        db_path: str = SESSION_DB_PATH,
+        ttl_hours: int = SESSION_TTL_HOURS,
+        max_sessions: int = SESSION_MAX_TOTAL,
+        cleanup_interval_minutes: int = 10,
+    ):
+        self.db_path = db_path
+        self.ttl = timedelta(hours=ttl_hours)
+        self.max_sessions = max_sessions
+        self.cleanup_interval = timedelta(minutes=cleanup_interval_minutes)
+        self.sessions: dict[str, Session] = {}
+        self._cleanup_task: asyncio.Task | None = None
+        self.conn: sqlite3.Connection | None = None
+
+        self._init_db()
+        self._load_sessions_from_db()
+
+        ttl_label = "never" if ttl_hours == 0 else f"{ttl_hours}h"
+        logger.info(
+            f"SessionManager initialized: TTL={ttl_label}, "
+            f"max={max_sessions}, DB={db_path}"
+        )
+
+    def _init_db(self) -> None:
+        db_dir = os.path.dirname(self.db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.executescript("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                title TEXT DEFAULT 'New Chat',
+                created_at TEXT NOT NULL,
+                last_accessed TEXT NOT NULL,
+                messages TEXT DEFAULT '[]'
+            );
+            CREATE INDEX IF NOT EXISTS idx_sessions_last_accessed
+                ON sessions(last_accessed);
+        """)
+        cols = [
+            row[1]
+            for row in self.conn.execute("PRAGMA table_info(sessions)").fetchall()
+        ]
+        if "user_id" not in cols:
+            self.conn.execute(
+                "ALTER TABLE sessions ADD COLUMN user_id TEXT DEFAULT ''"
+            )
+        self.conn.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_sessions_user_id
+                ON sessions(user_id);
+        """)
+        self.conn.commit()
+
+    def _load_sessions_from_db(self) -> None:
+        if not self.conn:
+            return
+        rows = self.conn.execute("SELECT * FROM sessions").fetchall()
+        loaded = 0
+        for row in rows:
+            last_accessed = datetime.fromisoformat(row["last_accessed"])
+            if self.ttl != timedelta(0) and datetime.now() - last_accessed > self.ttl:
+                self.conn.execute(
+                    "DELETE FROM sessions WHERE session_id = ?",
+                    (row["session_id"],),
+                )
+                continue
+            session = Session(
+                session_id=row["session_id"],
+                title=row["title"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+                last_accessed=last_accessed,
+                messages=json.loads(row["messages"]),
+                user_id=row["user_id"] or "",
+            )
+            self.sessions[session.session_id] = session
+            loaded += 1
+        self.conn.commit()
+        logger.info(f"Loaded {loaded} sessions from DB")
+
+    def _save_session(self, session: Session) -> None:
+        if not self.conn:
+            return
+        self.conn.execute(
+            """INSERT OR REPLACE INTO sessions
+               (session_id, title, created_at, last_accessed, messages, user_id)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session.session_id,
+                session.title,
+                session.created_at.isoformat(),
+                session.last_accessed.isoformat(),
+                json.dumps(session.messages),
+                session.user_id,
+            ),
+        )
+        self.conn.commit()
+
+    def _enforce_max_sessions(self) -> None:
+        if len(self.sessions) < self.max_sessions:
+            return
+        sorted_sessions = sorted(
+            self.sessions.values(), key=lambda s: s.last_accessed
+        )
+        to_remove = len(self.sessions) - self.max_sessions + 1
+        for session in sorted_sessions[:to_remove]:
+            self.delete_session(session.session_id)
+
+    def get_or_create_session(self, session_id: str, user_id: str = "") -> Session:
+        session = self.sessions.get(session_id)
+        if session and not self._is_expired(session):
+            if user_id and not session.user_id:
+                session.user_id = user_id
+            session.last_accessed = datetime.now()
+            self._save_session(session)
+            return session
+
+        if not session and self.conn:
+            row = self.conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row:
+                last_accessed = datetime.fromisoformat(row["last_accessed"])
+                if self.ttl == timedelta(0) or datetime.now() - last_accessed <= self.ttl:
+                    session = Session(
+                        session_id=row["session_id"],
+                        title=row["title"],
+                        created_at=datetime.fromisoformat(row["created_at"]),
+                        last_accessed=datetime.now(),
+                        messages=json.loads(row["messages"]),
+                        user_id=row["user_id"] or "",
+                    )
+                    self.sessions[session_id] = session
+                    self._save_session(session)
+                    return session
+
+        self._enforce_max_sessions()
+        now = datetime.now()
+        session = Session(
+            session_id=session_id,
+            title="New Chat",
+            created_at=now,
+            last_accessed=now,
+            messages=[],
+            user_id=user_id,
+        )
+        self.sessions[session_id] = session
+        self._save_session(session)
+        logger.info(f"Session created: {session_id} (user={user_id or 'anonymous'})")
+        return session
+
+    def append_messages(
+        self, session_id: str, user_msg: str, assistant_msg: str, user_id: str = ""
+    ) -> None:
+        session = self.get_or_create_session(session_id, user_id=user_id)
+        now = datetime.now().isoformat()
+        session.messages.append(
+            {"role": "user", "content": user_msg, "timestamp": now}
+        )
+        session.messages.append(
+            {"role": "assistant", "content": assistant_msg, "timestamp": now}
+        )
+        if session.title == "New Chat" and user_msg:
+            session.title = user_msg[:60].strip()
+        session.last_accessed = datetime.now()
+        self._save_session(session)
+
+    def list_sessions(self, user_id: str | None = None) -> list[dict]:
+        active = [
+            s for s in self.sessions.values() if not self._is_expired(s)
+        ]
+        if user_id is not None:
+            active = [s for s in active if s.user_id == user_id]
+        active.sort(key=lambda s: s.last_accessed, reverse=True)
+        return [s.to_summary() for s in active]
+
+    def get_session(self, session_id: str, user_id: str | None = None) -> Session | None:
+        session = self.sessions.get(session_id)
+        if session is None and self.conn:
+            row = self.conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row:
+                session = Session(
+                    session_id=row["session_id"],
+                    title=row["title"],
+                    created_at=datetime.fromisoformat(row["created_at"]),
+                    last_accessed=datetime.fromisoformat(row["last_accessed"]),
+                    messages=json.loads(row["messages"]),
+                    user_id=row["user_id"] or "",
+                )
+                self.sessions[session_id] = session
+
+        if session is None:
+            return None
+        if self._is_expired(session):
+            self.delete_session(session_id)
+            return None
+        if user_id is not None and session.user_id != user_id:
+            return None
+        return session
+
+    def delete_session(self, session_id: str, user_id: str | None = None) -> bool:
+        session = self.sessions.get(session_id)
+        if session and user_id is not None and session.user_id != user_id:
+            return False
+        session = self.sessions.pop(session_id, None)
+        if self.conn:
+            self.conn.execute(
+                "DELETE FROM sessions WHERE session_id = ?", (session_id,)
+            )
+            self.conn.commit()
+        if session:
+            logger.info(f"Session deleted: {session_id}")
+            return True
+        return False
+
+    def _is_expired(self, session: Session) -> bool:
+        if self.ttl == timedelta(0):
+            return False
+        return datetime.now() - session.last_accessed > self.ttl
+
+    async def cleanup_expired_sessions(self) -> None:
+        logger.info("Session cleanup task started")
+        while True:
+            try:
+                await asyncio.sleep(self.cleanup_interval.total_seconds())
+                if self.ttl == timedelta(0):
+                    continue
+                expired = [
+                    sid
+                    for sid, s in list(self.sessions.items())
+                    if self._is_expired(s)
+                ]
+                for sid in expired:
+                    self.delete_session(sid)
+                if self.conn:
+                    cutoff = (datetime.now() - self.ttl).isoformat()
+                    self.conn.execute(
+                        "DELETE FROM sessions WHERE last_accessed < ?",
+                        (cutoff,),
+                    )
+                    self.conn.commit()
+                if expired:
+                    logger.info(f"Cleaned up {len(expired)} expired sessions")
+            except asyncio.CancelledError:
+                logger.info("Session cleanup task cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Cleanup error: {e}", exc_info=True)
+
+    def start_cleanup_task(self) -> asyncio.Task:
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.create_task(
+                self.cleanup_expired_sessions()
+            )
+        return self._cleanup_task
+
+    def stop_cleanup_task(self) -> None:
+        if self._cleanup_task and not self._cleanup_task.done():
+            self._cleanup_task.cancel()
+
+    def build_conversation_context(
+        self,
+        session_id: str,
+        max_turns: int = SESSION_CONTEXT_MAX_TURNS,
+        user_id: str | None = None,
+    ) -> str:
+        try:
+            session = self.get_session(session_id, user_id=user_id)
+            if not session or not session.messages:
+                return ""
+            recent = session.messages[-(max_turns * 2):]
+            if not recent:
+                return ""
+            lines = []
+            for msg in recent:
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                if role == "assistant" and len(content) > 500:
+                    content = content[:500] + "... [truncated]"
+                lines.append(f"{role.upper()}: {content}")
+            return (
+                "=== CONVERSATION HISTORY ===\n"
+                + "\n\n".join(lines)
+                + "\n=== END HISTORY ===\n\n"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to load conversation context: {e}")
+            return ""
+{% endraw %}
+{%- endif %}

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/user_manager.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/user_manager.py
@@ -1,0 +1,137 @@
+{%- if values.enableAuth %}
+{% raw %}
+"""User Manager for password-based authentication.
+
+SQLite-backed user storage with bcrypt password hashing.
+"""
+
+import os
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+import bcrypt
+
+from shared.config import USERS_DB_PATH
+from shared.logging_config import setup_logging
+
+logger = setup_logging("user-manager")
+
+
+@dataclass
+class User:
+    user_id: str
+    username: str
+    created_at: datetime
+
+    def to_dict(self) -> dict:
+        return {
+            "user_id": self.user_id,
+            "username": self.username,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class UserManager:
+    """Manages user accounts with SQLite persistence and bcrypt hashing."""
+
+    def __init__(self, db_path: str = USERS_DB_PATH):
+        self.db_path = db_path
+        self.conn: sqlite3.Connection | None = None
+        self._init_db()
+        logger.info(f"UserManager initialized: DB={db_path}")
+
+    def _init_db(self) -> None:
+        db_dir = os.path.dirname(self.db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.executescript("""
+            CREATE TABLE IF NOT EXISTS users (
+                user_id TEXT PRIMARY KEY,
+                username TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_users_username
+                ON users(username);
+        """)
+        self.conn.commit()
+
+    def create_user(self, username: str, password: str) -> User:
+        """Create a new user. Raises ValueError if username taken."""
+        if not username or not password:
+            raise ValueError("Username and password are required")
+        if len(username) < 3:
+            raise ValueError("Username must be at least 3 characters")
+        if len(password) < 6:
+            raise ValueError("Password must be at least 6 characters")
+
+        user_id = str(uuid.uuid4())
+        password_hash = bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt()
+        ).decode("utf-8")
+        now = datetime.now()
+
+        try:
+            self.conn.execute(
+                "INSERT INTO users (user_id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+                (user_id, username, password_hash, now.isoformat()),
+            )
+            self.conn.commit()
+        except sqlite3.IntegrityError:
+            raise ValueError(f"Username '{username}' is already taken")
+
+        logger.info(f"User created: {username} ({user_id})")
+        return User(user_id=user_id, username=username, created_at=now)
+
+    def authenticate(self, username: str, password: str) -> User | None:
+        """Authenticate a user. Returns User if valid, None otherwise."""
+        row = self.conn.execute(
+            "SELECT * FROM users WHERE username = ?", (username,)
+        ).fetchone()
+        if not row:
+            return None
+
+        if not bcrypt.checkpw(
+            password.encode("utf-8"), row["password_hash"].encode("utf-8")
+        ):
+            return None
+
+        return User(
+            user_id=row["user_id"],
+            username=row["username"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def get_user(self, user_id: str) -> User | None:
+        """Get a user by ID."""
+        row = self.conn.execute(
+            "SELECT * FROM users WHERE user_id = ?", (user_id,)
+        ).fetchone()
+        if not row:
+            return None
+        return User(
+            user_id=row["user_id"],
+            username=row["username"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def list_users(self) -> list[dict]:
+        """List all users (without password hashes)."""
+        rows = self.conn.execute(
+            "SELECT user_id, username, created_at FROM users ORDER BY created_at"
+        ).fetchall()
+        return [
+            {
+                "user_id": row["user_id"],
+                "username": row["username"],
+                "created_at": row["created_at"],
+            }
+            for row in rows
+        ]
+{% endraw %}
+{%- endif %}

--- a/examples/templates/crewai-agent/content-agent/src/shared/a2a_utils.py
+++ b/examples/templates/crewai-agent/content-agent/src/shared/a2a_utils.py
@@ -1,0 +1,28 @@
+{% raw %}
+"""Shared A2A protocol utilities.
+
+Extracted from duplicated code across executor modules.
+"""
+
+from __future__ import annotations
+
+from a2a.types import TextPart
+
+
+def extract_user_input(message, default: str = "Hello") -> str:
+    """Extract the user's text input from an A2A message.
+
+    Handles both direct TextPart instances and wrapped Part objects
+    (where the TextPart is nested under .root).
+    """
+    if message and message.parts:
+        text_parts = []
+        for part in message.parts:
+            if isinstance(part, TextPart):
+                text_parts.append(part.text)
+            elif hasattr(part, "root") and isinstance(part.root, TextPart):
+                text_parts.append(part.root.text)
+        if text_parts:
+            return " ".join(text_parts)
+    return default
+{% endraw %}

--- a/examples/templates/crewai-agent/content-agent/src/shared/config.py
+++ b/examples/templates/crewai-agent/content-agent/src/shared/config.py
@@ -52,4 +52,20 @@ SUB_AGENT_URL = os.getenv(
 # "text" for local development (human-readable with timestamps)
 LOG_FORMAT = os.getenv("LOG_FORMAT", "text")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+# --- CREWAI ---
+CREWAI_VERBOSE = os.getenv("CREWAI_VERBOSE", "true").lower() == "true"
+
+# --- SINGLE AGENT BYPASS ---
+# When True and there's only one sub-agent, skip keyword classification
+# and always route to the sub-agent directly.
+SINGLE_AGENT_BYPASS = os.getenv("SINGLE_AGENT_BYPASS", "true").lower() == "true"
 {% endraw %}
+{%- if values.enableAuth %}
+{% raw %}
+# --- AUTH ---
+JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret-change-me")
+JWT_EXPIRY_HOURS = int(os.getenv("JWT_EXPIRY_HOURS", "24"))
+USERS_DB_PATH = os.getenv("USERS_DB_PATH", "/data/users.db")
+{% endraw %}
+{%- endif %}

--- a/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/external-secret.yaml
+++ b/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/external-secret.yaml
@@ -57,6 +57,13 @@ spec:
       remoteRef:
         key: ${{ values.vaultRole }}
         property: api-keys
+{%- if values.enableAuth %}
+    # JWT signing secret for user authentication
+    - secretKey: jwt-secret
+      remoteRef:
+        key: ${{ values.vaultRole }}
+        property: jwt-secret
+{%- endif %}
 
 ---
 # ------------------------------------------------------------------------------

--- a/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/configmap.yaml
+++ b/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/configmap.yaml
@@ -33,3 +33,11 @@ data:
   # Internal service DNS name for the sub-agent
   # Format: http://<service-name>.<namespace>.svc:<port>
   SUB_AGENT_URL: "http://${{ values.name }}-${{ values.subAgentName }}.${{ values.namespace }}.svc:${{ values.subAgentPort }}"
+  # CrewAI verbose logging (set to "false" in production to reduce log noise)
+  CREWAI_VERBOSE: "true"
+{%- if values.enableSessions %}
+  # Session persistence configuration
+  USERS_DB_PATH: "/data/users.db"
+  SESSION_DB_PATH: "/data/sessions.db"
+  SESSION_TTL_HOURS: "0"
+{%- endif %}

--- a/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/deployment.yaml
+++ b/examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/deployment.yaml
@@ -87,6 +87,13 @@ spec:
                 secretKeyRef:
                   name: ${{ values.name }}-orchestrator-secrets
                   key: api-keys
+{%- if values.enableAuth %}
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ values.name }}-orchestrator-secrets
+                  key: jwt-secret
+{%- endif %}
 
           # Mount persistent storage for session data / CrewAI memory
           volumeMounts:

--- a/examples/templates/crewai-agent/template.yaml
+++ b/examples/templates/crewai-agent/template.yaml
@@ -130,6 +130,30 @@ spec:
             The orchestrator uses keyword matching (not LLM) for fast, deterministic routing.
           ui:help: 'Example: chores, tasks, assignments, household, todo, schedule'
 
+        enableAuth:
+          title: Enable Authentication
+          type: boolean
+          description: >-
+            Add JWT + API key authentication with user management (register/login).
+            Includes bcrypt password hashing and SQLite user storage.
+          default: true
+
+        enableSessions:
+          title: Enable Session Persistence
+          type: boolean
+          description: >-
+            Add SQLite-backed conversation sessions with TTL expiration,
+            context injection, and background cleanup.
+          default: true
+
+        enableCopilotKit:
+          title: Enable CopilotKit (AG-UI)
+          type: boolean
+          description: >-
+            Add a /copilotkit SSE endpoint for CopilotKit frontend integration.
+            Requires ag-ui-protocol dependency.
+          default: false
+
     # --- WIZARD PAGE 3: Sub-Agent Configuration ---
     # Each sub-agent is an independent CrewAI agent with its own tools,
     # knowledge sources, and A2A endpoint.
@@ -307,6 +331,9 @@ spec:
           subAgentGoal: ${{ parameters.subAgentGoal }}
           subAgentPort: ${{ parameters.subAgentPort }}
           enableKnowledge: ${{ parameters.enableKnowledge }}
+          enableAuth: ${{ parameters.enableAuth }}
+          enableSessions: ${{ parameters.enableSessions }}
+          enableCopilotKit: ${{ parameters.enableCopilotKit }}
           subAgentBackstory: ${{ parameters.subAgentBackstory }}
           domain: ${{ parameters.domain }}
           vaultRole: ${{ parameters.vaultRole if parameters.vaultRole else parameters.name }}
@@ -335,6 +362,9 @@ spec:
           subAgentGoal: ${{ parameters.subAgentGoal }}
           subAgentPort: ${{ parameters.subAgentPort }}
           enableKnowledge: ${{ parameters.enableKnowledge }}
+          enableAuth: ${{ parameters.enableAuth }}
+          enableSessions: ${{ parameters.enableSessions }}
+          enableCopilotKit: ${{ parameters.enableCopilotKit }}
           subAgentBackstory: ${{ parameters.subAgentBackstory }}
           domain: ${{ parameters.domain }}
           vaultRole: ${{ parameters.vaultRole if parameters.vaultRole else parameters.name }}
@@ -362,6 +392,7 @@ spec:
         vaultRole: ${{ parameters.vaultRole if parameters.vaultRole else parameters.name }}
         namespace: ${{ parameters.namespace }}
         enableKnowledge: ${{ parameters.enableKnowledge }}
+        enableAuth: ${{ parameters.enableAuth }}
 
     # Step 5 (production): Create PR for agent code in the claude-agents monorepo.
     # IMPORTANT: This must happen BEFORE dispatching the build workflow, because


### PR DESCRIPTION
## Summary

Brings the Backstage CrewAI agent template in sync with production `oncall-crewai` patterns so newly scaffolded agents get auth, sessions, CopilotKit, and smart routing out of the box.

- **Auth (JWT + API keys)**: New `auth.py` and `user_manager.py` with register/login endpoints, bcrypt hashing, SQLite user storage
- **Session persistence**: New `session_manager.py` with SQLite-backed sessions, TTL expiration, context injection, background cleanup
- **CopilotKit/AG-UI**: New `copilotkit_endpoint.py` with SSE streaming for CopilotKit frontend integration
- **Routing fixes**: Single-agent bypass (skip classification when only one sub-agent), removed dead-end `NO_MATCH_RESPONSE`
- **Flow persistence**: Optional `@persist` decorator for crash recovery
- **A2A utilities**: New `a2a_utils.py` shared module
- **A2A timeout**: Bumped from 120s to 300s for heavy queries
- **Template wizard**: Added `enableAuth`, `enableSessions`, `enableCopilotKit` boolean parameters
- **K8s manifests**: Added `JWT_SECRET` env, session config to ConfigMap, jwt-secret to ExternalSecret

### New files (5)
| File | Feature |
|------|---------|
| `content-agent/src/orchestrator/auth.py` | JWT + API key dual auth |
| `content-agent/src/orchestrator/user_manager.py` | SQLite user accounts with bcrypt |
| `content-agent/src/orchestrator/session_manager.py` | Conversation persistence |
| `content-agent/src/orchestrator/copilotkit_endpoint.py` | AG-UI SSE streaming |
| `content-agent/src/shared/a2a_utils.py` | A2A protocol utilities |

### Modified files (10)
| File | Changes |
|------|---------|
| `config.py` | Added `CREWAI_VERBOSE`, `SINGLE_AGENT_BYPASS`, conditional auth vars |
| `prompts.py` | Removed `NO_MATCH_RESPONSE` |
| `flow.py` | Single-agent bypass, `@persist`, removed no_match dead-end |
| `agents.py` | A2A timeout 120→300s |
| `main.py` | Full production version with conditional auth/sessions/CopilotKit |
| `requirements.txt` | Added PyJWT, bcrypt, ag-ui-protocol (conditional) |
| `template.yaml` | Added 3 wizard parameters, passed to fetch steps |
| `configmap.yaml` | Added `CREWAI_VERBOSE`, session config |
| `external-secret.yaml` | Added `jwt-secret` key |
| `deployment.yaml` | Added `JWT_SECRET` env from secret |

## Test plan
- [ ] Scaffold with `enableAuth: true`, `enableSessions: true` → verify auth + session endpoints present
- [ ] Scaffold with `enableAuth: false` → verify `/invoke` works without auth
- [ ] Scaffold with `enableCopilotKit: true` → verify `/copilotkit` endpoint exists
- [ ] Scaffold with all defaults → verify no import errors, Docker build succeeds
- [ ] Dry run in Backstage UI to verify template renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)