### PR TITLE
Fix vault:setup InputError for enableAuth parameter

### DIFF
--- a/examples/templates/crewai-agent/content-agent/src/${{ values.subAgentPythonName }}/prompts.py
+++ b/examples/templates/crewai-agent/content-agent/src/${{ values.subAgentPythonName }}/prompts.py
@@ -32,7 +32,9 @@ AGENT_GOAL = "${{ values.subAgentGoal }}"
 # The agent's backstory — this is the main prompt that shapes LLM behavior.
 # Populated from the "CrewAI Backstory (Prompt)" field in the template wizard.
 # Edit this to refine the agent's behavior as you add tools and knowledge sources.
-AGENT_BACKSTORY = """${{ values.subAgentBackstory }}"""
+AGENT_BACKSTORY = """
+${{ values.subAgentBackstory }}
+"""
 
 # Task description template — used when the orchestrator delegates a query.
 # The {query} placeholder is replaced with the actual user query at runtime.

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
@@ -273,7 +273,7 @@ def create_app() -> FastAPI:
         return {
             "service": PROJECT_NAME,
             "role": "orchestrator",
-            "copilotkit": {% endraw %}{{ "true" if values.enableCopilotKit else "false" }}{% raw %},
+            "copilotkit": {% endraw %}{{ "True" if values.enableCopilotKit else "False" }}{% raw %},
             "sub_agents": [
                 {
                     "name": "{% endraw %}${{ values.subAgentName }}{% raw %}",

--- a/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
+++ b/examples/templates/crewai-agent/content-agent/src/orchestrator/main.py
@@ -273,7 +273,7 @@ def create_app() -> FastAPI:
         return {
             "service": PROJECT_NAME,
             "role": "orchestrator",
-            "copilotkit": {% endraw %}{{ "True" if values.enableCopilotKit else "False" }}{% raw %},
+            "copilotkit": {% endraw %}${{ "True" if values.enableCopilotKit else "False" }}{% raw %},
             "sub_agents": [
                 {
                     "name": "{% endraw %}${{ values.subAgentName }}{% raw %}",

--- a/packages/backend/src/modules/scaffolder/vaultSetupAction.ts
+++ b/packages/backend/src/modules/scaffolder/vaultSetupAction.ts
@@ -65,6 +65,7 @@ async function vaultRequest(
  *   - vaultRole (required): Vault role name (also used for policy and secret path)
  *   - namespace (required): K8s namespace for ServiceAccount binding
  *   - enableKnowledge (optional): If true, seeds an openai-api-key placeholder
+ *   - enableAuth (optional): If true, seeds a jwt-secret placeholder
  *   - serviceAccountNames (optional): Comma-separated SA names, defaults to "default"
  *
  * Outputs:
@@ -99,6 +100,14 @@ export function createVaultSetupAction() {
             .describe(
               'If true, seeds an openai-api-key placeholder for RAG embeddings',
             ),
+        enableAuth: z =>
+          z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe(
+              'If true, seeds a jwt-secret placeholder for JWT authentication',
+            ),
         serviceAccountNames: z =>
           z
             .string()
@@ -122,6 +131,7 @@ export function createVaultSetupAction() {
         vaultRole,
         namespace,
         enableKnowledge = false,
+        enableAuth = false,
         serviceAccountNames = 'default',
       } = ctx.input;
 
@@ -211,6 +221,9 @@ export function createVaultSetupAction() {
       const requiredKeys: string[] = ['anthropic-api-key', 'api-keys'];
       if (enableKnowledge) {
         requiredKeys.push('openai-api-key');
+      }
+      if (enableAuth) {
+        requiredKeys.push('jwt-secret');
       }
 
       // Try to read existing secrets from Vault


### PR DESCRIPTION
## Summary
- The `vault:setup` scaffolder action schema didn't declare `enableAuth` as a valid input parameter
- The CrewAI template (from PR #2) passes `enableAuth` to vault:setup, causing `InputError: instance is not allowed to have the additional property "enableAuth"` during scaffolding
- Added `enableAuth` (boolean, optional, default false) to the action's input schema
- When `enableAuth` is true, the action now seeds a `jwt-secret` placeholder in Vault alongside the existing `anthropic-api-key` and `api-keys`

## Root Cause
PR #2 added `enableAuth: ${{ parameters.enableAuth }}` to the vault:setup step input in `template.yaml`, but the corresponding `vaultSetupAction.ts` was not updated to accept this parameter. Backstage's scaffolder validates action inputs strictly against the declared schema.

## Test plan
- [ ] Scaffold a new agent with `enableAuth: true` — verify vault:setup completes without error
- [ ] Verify `jwt-secret` placeholder appears in Vault at the project's secret path
- [ ] Scaffold with `enableAuth: false` — verify no `jwt-secret` is seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)