### PR TITLE
fix(config): register application-template in production config overlay

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -101,6 +101,13 @@ catalog:
       rules:
         - allow: [Template]
 
+    # Application (Crossplane) — onboard a container image as a managed app.
+    # See: examples/templates/application/template.yaml
+    - type: file
+      target: ./examples/templates/application/template.yaml
+      rules:
+        - allow: [Template]
+
     - type: file
       target: ./examples/org.yaml
       rules:


### PR DESCRIPTION
## Why

After merging PR #4 (adds the `application-template`) and rebuilding `backstage-portal:v1.0.2`, the new template **does not appear** in the Backstage UI alongside CrewAI / Example Node.js.

## Root cause

`app-config.production.yaml` defines its **own** `catalog.locations` array (5 entries) which **replaces** the base `app-config.yaml`'s array (Backstage merges production-overlay on top of base; arrays at the same key are replaced, not concatenated). PR #4 only added the new entry to `app-config.yaml`, so the production overlay silently dropped it.

Confirmed via `kubectl exec` against the running v1.0.2 pod:

- File at `/app/examples/templates/application/template.yaml` ✅ exists, byte-identical to PR #4
- Base `app-config.yaml` `catalog.locations` includes the new entry ✅
- Production `app-config.production.yaml` `catalog.locations` does **not** include it ❌
- Postgres `final_entities` table has only `crewai-agent-template` and `example-nodejs-template` — no `application-template` row
- Postgres `refresh_state` confirms no `Location` entity exists for `examples/templates/application/template.yaml`

## Fix

Add the same `type: file` registration to `app-config.production.yaml`, between the CrewAI entry and `org.yaml`. Uses the production relative-path convention (`./...` from `/app`, vs base config's `../../...` from `packages/backend/`).

## After merge

1. Rebuild `backstage-portal` (suggest tag `v1.0.3`).
2. Bump the deployed tag in `arigsela/kubernetes:base-apps/backstage/deployments.yaml`.
3. After ArgoCD rolls the new pod, **Application (Crossplane)** will appear at https://backstage.arigsela.com/create alongside CrewAI / Example Node.js.

## Test plan

- [ ] After redeploy, query `final_entities`: `template:default/application-template` row exists.
- [ ] `/create` page shows three template cards (Example Node.js + CrewAI + Application (Crossplane)).
- [ ] Clicking the new card walks the 3-page wizard without errors.

## Lesson for the plan

This caught a gap in `arigsela/kubernetes:docs/superpowers/plans/2026-04-28-backstage-crossplane-idp.md` Task 3.3 — the plan only mentioned editing `app-config.yaml`, not `app-config.production.yaml`. I'll backport this lesson to the plan in a follow-up commit on the kubernetes repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)