### PR TITLE
fix(template): drop catalog:register step (broken output reference)

### DIFF
--- a/examples/templates/application/template.yaml
+++ b/examples/templates/application/template.yaml
@@ -105,17 +105,16 @@ spec:
           Database: ${{ parameters.dbNeeded }}
         targetPath: ""
 
-    - id: register
-      name: Register in catalog
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: /base-apps/${{ parameters.name }}/catalog-info.yaml
+  # NOTE: no catalog:register step here. `publish:github:pull-request` does NOT
+  # emit a `repoContentsUrl` output (only the direct-push `publish:github` does),
+  # and there's no clean URL we can register pre-merge — the catalog-info.yaml
+  # only exists on the feature branch until the PR merges. After merging, the
+  # operator manually imports via /catalog-import:
+  #   https://github.com/arigsela/kubernetes/blob/main/base-apps/<name>/catalog-info.yaml
+  # Future improvement: extend the GitHub catalog provider in app-config to scan
+  # `base-apps/*/catalog-info.yaml` so registration is fully automatic.
 
   output:
     links:
       - title: Pull request
         url: ${{ steps.publish.output.remoteUrl }}
-      - title: Catalog entry
-        icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}


### PR DESCRIPTION
## Why

Phase 4 e2e ran the new template against the live UI. Render + Open PR succeeded; **catalog:register failed** with:

```
Error: Invalid input passed to action catalog:register, instance is not any of [subschema 0],[subschema 1]
```

PR #204 in arigsela/kubernetes — `scaffold/helloapp` — opened correctly with all three rendered files. The diagnosis is purely on the trailing register step.

## Root cause

The template referenced `${{ steps.publish.output.repoContentsUrl }}`, but `publish:github:pull-request` does **not** emit a `repoContentsUrl` output — only the direct-push `publish:github` action does. With the value undefined, catalog:register's input failed JSON-schema validation against both alternative subschemas, aborting the run.

Even if the output existed, registering pre-merge is unclean: the catalog-info.yaml only exists on the feature branch (vanishes after squash-merge or branch delete), and pointing the catalog at a transient URL orphans the entity later.

The sibling `crewai-agent` template uses the same `publish:github:pull-request` action and **omits `catalog:register` entirely** for this same reason.

## Fix

Drop the register step. Add an inline comment in the template explaining the trade-off and the manual workflow:

> After PR merge → /catalog-import → paste `https://github.com/arigsela/kubernetes/blob/main/base-apps/<name>/catalog-info.yaml`

## After merge

Rebuild backstage-portal once more (e.g. `v1.0.4`) and bump the deployed tag in arigsela/kubernetes:base-apps/backstage/deployments.yaml.

Re-run the wizard for `helloapp` after redeploy → all three steps green; PR opens (this time without the failed register).

## Future improvement (separate scope)

Extend the GitHub catalog provider in `app-config.{yaml,production.yaml}` to scan `base-apps/*/catalog-info.yaml` directly, so registration becomes fully automatic with no manual import step. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)