### PR TITLE
fix(template): exclude catalog-info.yaml from ArgoCD sync (future scaffolds)

### DIFF
--- a/examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml
+++ b/examples/templates/application/content-k8s/base-apps/${{ values.name }}.yaml
@@ -13,6 +13,12 @@ spec:
     repoURL: https://github.com/arigsela/kubernetes
     targetRevision: main
     path: base-apps/${{ values.name }}
+    # catalog-info.yaml is a Backstage Component entity (backstage.io/v1alpha1),
+    # not a Kubernetes resource. Backstage reads it directly from GitHub raw
+    # via /catalog-import. ArgoCD must skip it or sync fails with
+    # "no matches for kind Component".
+    directory:
+      exclude: 'catalog-info.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: ${{ values.namespace }}


### PR DESCRIPTION
## Why

Companion of [arigsela/kubernetes#207](https://github.com/arigsela/kubernetes/pull/207). Without this fix, every future scaffolded app's ArgoCD Application would fail with the same error #207 fixes.

## What changes

Adds `directory.exclude: 'catalog-info.yaml'` to the rendered ArgoCD Application spec in the Nunjucks template at `content-k8s/base-apps/${{ values.name }}.yaml`.

## After merge

Rebuild image (suggest `v1.0.5`) and bump the deployed tag in arigsela/kubernetes:base-apps/backstage/deployments.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)