### PR TITLE
fix(backend): disable default auth policy for single-process Backstage

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -27,6 +27,15 @@ app:
 
 # --- BACKEND ---
 backend:
+  # SERVICE-TO-SERVICE AUTH (mirrors base app-config):
+  # Backstage v1.x requires backend plugins to authenticate when calling each
+  # other internally. Without a shared secret, scheduled-task plugins (TeraSky's
+  # kubernetes-ingestor in v1.1) get 401 "Missing credentials" on internal
+  # /api/kubernetes/proxy/... calls. dangerouslyDisableDefaultAuthPolicy=true
+  # is the documented escape hatch for single-process homelab Backstage.
+  auth:
+    dangerouslyDisableDefaultAuthPolicy: true
+
   # The baseUrl must be reachable by all clients (browsers, other services).
   # This URL is used by the frontend to construct API requests to the backend.
   baseUrl: https://backstage.arigsela.com

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -33,13 +33,22 @@ organization:
 # --- BACKEND ---
 # Configuration for the Backstage backend server.
 backend:
-  # SERVICE-TO-SERVICE AUTH (commented out for dev):
-  # In production, backend plugins authenticate with each other using a shared secret.
-  # Without this, each backend restart generates new signing keys, breaking cross-service auth.
-  # TODO (Phase 7): Uncomment and set BACKEND_SECRET for production.
-  # auth:
-  #   keys:
-  #     - secret: ${BACKEND_SECRET}
+  # SERVICE-TO-SERVICE AUTH:
+  # Backstage v1.x's new backend system requires backend plugins to authenticate
+  # to each other when making internal API calls. With permission.enabled=true
+  # and no shared secret, scheduled-task plugins (like TeraSky's kubernetes-ingestor
+  # in v1.1) get 401 "Missing credentials" when calling /api/kubernetes/proxy/...
+  #
+  # `dangerouslyDisableDefaultAuthPolicy: true` is the documented escape hatch
+  # for single-process Backstage where all plugins run in one Node.js process —
+  # which is our homelab single-user case. For multi-process or multi-tenant
+  # production setups, switch to a real shared secret via:
+  #   auth:
+  #     keys:
+  #       - secret: ${BACKEND_SECRET}
+  # plus a Vault-backed BACKEND_SECRET in the K8s ExternalSecret + deployment env.
+  auth:
+    dangerouslyDisableDefaultAuthPolicy: true
 
   baseUrl: http://localhost:7007 # URL where the backend API is accessible
   listen:


### PR DESCRIPTION
## Why

After v1.1.0 deployed, TeraSky's `kubernetes-ingestor` plugin's scheduled-task runs hit `401 Missing credentials` calling `/api/kubernetes/proxy/apis/apiextensions.k8s.io/v1/customresourcedefinitions`. The error makes the plugin unable to discover XRDs, blocking auto-ingestion of XApplications as catalog entities (which is the whole point of v1.1).

## Diagnosis

- Cluster RBAC is fine — `kubectl auth can-i list customresourcedefinitions --as system:serviceaccount:backstage:backstage` returns `yes`, and that token returns 200 directly against the K8s API.
- The 401 comes from **Backstage's own auth middleware**. Modern Backstage v1.x requires backend-to-backend service tokens for internal plugin calls when `permission.enabled=true`. Scheduled tasks (no user context) need a shared secret to sign those tokens.
- Our config has `backend.auth.keys` commented out (v1.0.x's TODO from Phase 7). With no shared secret, internal plugin calls can't auth.

## Fix

Add `backend.auth.dangerouslyDisableDefaultAuthPolicy: true` to BOTH `app-config.yaml` and `app-config.production.yaml` (production-overlay-replaces-base rule from v1).

This is the documented escape hatch for single-process Backstage where all plugins run in one Node.js process. For multi-process or multi-tenant production, replace with real shared-secret service tokens via `backend.auth.keys` — out of scope for our homelab single-user use case.

## After merge

Rebuild image (suggest `v1.1.1`) and bump tag in arigsela/kubernetes:base-apps/backstage/deployments.yaml. After ArgoCD rolls, the kubernetes-ingestor's next scheduled run succeeds and XApplications start auto-ingesting.

The currently-stuck scaffolder task may also self-resolve (the kubernetes-ingestor's repeated failures may have been starving shared scheduler resources). If not, restart the Backstage pod after the rebuild lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)