### PR TITLE
feat(scaffolder): v1.2.1 ergonomic fixes — healthCheckPath + form trim

### DIFF
--- a/examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml
+++ b/examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml
@@ -19,5 +19,8 @@ spec:
   host: ${{ values.host }}
   port: ${{ values.port }}
   replicas: ${{ values.replicas }}
+  {%- if values.healthCheckPath and values.healthCheckPath != "/" %}
+  healthCheckPath: ${{ values.healthCheckPath }}
+  {%- endif %}
   dbNeeded: ${{ values.dbNeeded }}
   dbStorage: ${{ values.dbStorage }}

--- a/examples/templates/application/template.yaml
+++ b/examples/templates/application/template.yaml
@@ -58,6 +58,12 @@ spec:
           default: 2
           minimum: 1
           maximum: 10
+        healthCheckPath:
+          type: string
+          title: Health check path (optional)
+          description: HTTP path for liveness/readiness probes. Defaults to '/' which works for most images (nginx, generic web servers).
+          default: "/"
+          pattern: "^/.*"
 
     - title: Database (optional)
       properties:
@@ -77,15 +83,16 @@ spec:
       input:
         url: ./content-k8s
         values:
-          name: ${{ parameters.name }}
-          namespace: ${{ parameters.name }}
-          owner: ${{ parameters.owner }}
-          image: ${{ parameters.image }}
-          host: ${{ parameters.host }}
+          name: ${{ parameters.name | trim }}
+          namespace: ${{ parameters.name | trim }}
+          owner: ${{ parameters.owner | trim }}
+          image: ${{ parameters.image | trim }}
+          host: ${{ parameters.host | trim }}
+          healthCheckPath: ${{ parameters.healthCheckPath | trim }}
           port: ${{ parameters.port }}
           replicas: ${{ parameters.replicas }}
           dbNeeded: ${{ parameters.dbNeeded }}
-          dbStorage: ${{ parameters.dbStorage }}
+          dbStorage: ${{ parameters.dbStorage | trim }}
 
     - id: publish
       name: Open PR to arigsela/kubernetes


### PR DESCRIPTION
## Summary

Companion to [arigsela/kubernetes v1.2.1 PR](https://github.com/arigsela/kubernetes/pull/226) — adds the Backstage scaffolder side of the v1.2 close-out fixes.

## Changes

| Change | File | Why |
|---|---|---|
| Add `healthCheckPath` optional form input in "Workload" group | `examples/templates/application/template.yaml` | Lets users override the default `/` probe path for images that expose dedicated health endpoints |
| Apply Nunjucks `| trim` filter to text values (name, owner, image, host, healthCheckPath, dbStorage) | `examples/templates/application/template.yaml` (steps.fetch.input.values) | Sanitizes form-input whitespace before it lands in XR yaml — discovered during v1.2 validation when PR `scaffold/smoke-v12` had `host: "smoke-v12.arigsela.com "` |
| Conditional emission of `healthCheckPath` in rendered XR | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | Only emit when user picks non-default — keeps XR yaml clean for the common case |

## Test plan

- [ ] After merge + Backstage image rebuild, scaffold a new app with deliberate trailing whitespace on `host` field — verify scaffold PR has clean values
- [ ] Default healthCheckPath path: form populated with `/` → XR omits the field (XRD default kicks in)
- [ ] Override healthCheckPath: form set to e.g. `/api/health` → XR includes the field

## Companion PR

Composition / XRD side: arigsela/kubernetes#226

## Image rebuild needed?

Yes. After this merges, the Backstage image needs to be rebuilt and `base-apps/backstage/deployments.yaml` tag bumped per the CLAUDE.md user-owned image-rebuild flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)