### PR TITLE
feat(scaffolder): v1.3 add s3Needed form input

### DIFF
--- a/examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml
+++ b/examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml
@@ -24,3 +24,4 @@ spec:
   {%- endif %}
   dbNeeded: ${{ values.dbNeeded }}
   dbStorage: ${{ values.dbStorage }}
+  s3Needed: ${{ values.s3Needed }}

--- a/examples/templates/application/template.yaml
+++ b/examples/templates/application/template.yaml
@@ -65,7 +65,7 @@ spec:
           default: "/"
           pattern: "^/.*"
 
-    - title: Database (optional)
+    - title: Resources (optional)
       properties:
         dbNeeded:
           type: boolean
@@ -75,6 +75,16 @@ spec:
           type: string
           title: Database storage size
           default: "1Gi"
+        s3Needed:
+          type: boolean
+          title: Provision an AWS S3 bucket (with dedicated IAM user)
+          description: |
+            When enabled, the platform creates an S3 bucket + IAM user + access
+            key for this app. Workload receives AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+            AWS_REGION, BUCKET_NAME env vars automatically (zero code changes — AWS SDK
+            auto-detects).
+            WARNING: bucket contents are deleted when the app is torn down (forceDestroy).
+          default: false
 
   steps:
     - id: fetch
@@ -93,6 +103,7 @@ spec:
           replicas: ${{ parameters.replicas }}
           dbNeeded: ${{ parameters.dbNeeded }}
           dbStorage: ${{ parameters.dbStorage | trim }}
+          s3Needed: ${{ parameters.s3Needed }}
 
     - id: publish
       name: Open PR to arigsela/kubernetes


### PR DESCRIPTION
## Summary

Companion to [arigsela/kubernetes v1.3 PR #231](https://github.com/arigsela/kubernetes/pull/231) — adds the Backstage scaffolder side: `s3Needed` form input + rendered XR field.

## Changes

| Change | File | Why |
|---|---|---|
| Rename "Database (optional)" group to "Resources (optional)" | `examples/templates/application/template.yaml` | Group now covers both DB and S3 |
| Add `s3Needed` boolean form field | (same file) | Lets users opt into S3 bucket + IAM provisioning at scaffold time |
| Add `s3Needed` to `fetch.values` mapping | (same file) | Threads form value to content-k8s template |
| Render `s3Needed` in XR template | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/application-xr.yaml` | XR contains the field; cluster-side Composition reads it |

## Test plan

- [ ] After Backstage image rebuild, scaffold an app with s3Needed:true — verify XR rendered with s3Needed:true
- [ ] Default behavior (s3Needed unchecked) → XR has s3Needed:false (existing apps unaffected)

## Image rebuild needed?

Yes. After this merges, the Backstage image needs to be rebuilt and `base-apps/backstage/deployments.yaml` tag bumped (or tag reused + pod relaunched, like v1.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)