### PR TITLE
feat(scaffolder): v1.3.1 emit AWS resources as raw manifests (Option B)

### DIFF
--- a/examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml
+++ b/examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml
@@ -1,0 +1,143 @@
+{%- if values.s3Needed %}
+# AWS resources for ${{ values.name }} — provisioned via Crossplane provider-aws-s3
+# and provider-aws-iam (cluster-scoped resources, applied by ArgoCD).
+#
+# WARNING: bucket has forceDestroy:true — contents are permanently deleted on
+# teardown. The IAM user + access key are dedicated per-app (not shared).
+#
+# Cross-resource references via Crossplane label selectors (resolved at apply time
+# by the Crossplane controllers; no sync waves needed). Matches the existing
+# loki-aws-infrastructure / argo-workflows-aws-infrastructure pattern.
+
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: ${{ values.bucketName }}
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: bucket
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    region: us-east-2
+    forceDestroy: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: ${{ values.name }}-app
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-user
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    tags:
+      ManagedBy: crossplane
+      App: ${{ values.name }}
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: ${{ values.name }}-s3-policy
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    description: "S3 RW on ${{ values.name }}'s own bucket"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+          "Resource": [
+            "arn:aws:s3:::${{ values.bucketName }}",
+            "arn:aws:s3:::${{ values.bucketName }}/*"
+          ]
+        }]
+      }
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: ${{ values.name }}-s3-attachment
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: iam-policy-attachment
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-policy
+    userRef:
+      name: ${{ values.name }}-app
+  providerConfigRef:
+    name: default
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: ${{ values.name }}-app-key
+  labels:
+    app.kubernetes.io/name: ${{ values.name }}
+    app.kubernetes.io/component: access-key
+    app.kubernetes.io/managed-by: crossplane
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/owner: ${{ values.owner }}
+    terasky.backstage.io/component-type: service
+    terasky.backstage.io/lifecycle: experimental
+    terasky.backstage.io/system: platform
+    backstage.io/source-location: url:https://github.com/arigsela/kubernetes/tree/main/base-apps/${{ values.name }}
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        app.kubernetes.io/name: ${{ values.name }}
+        app.kubernetes.io/component: iam-user
+  # Connection secret keys: attribute.id, attribute.secret, username
+  writeConnectionSecretToRef:
+    name: ${{ values.name }}-aws-key
+    namespace: ${{ values.name }}
+  providerConfigRef:
+    name: default
+{%- endif %}

--- a/examples/templates/application/template.yaml
+++ b/examples/templates/application/template.yaml
@@ -104,6 +104,7 @@ spec:
           dbNeeded: ${{ parameters.dbNeeded }}
           dbStorage: ${{ parameters.dbStorage | trim }}
           s3Needed: ${{ parameters.s3Needed }}
+          bucketName: 852893458518-${{ parameters.name | trim }}
 
     - id: publish
       name: Open PR to arigsela/kubernetes


### PR DESCRIPTION
## Summary

Companion to arigsela/kubernetes v1.3.1 PR. Adds the scaffolder side: when developer scaffolds with `s3Needed:true`, the scaffolder emits a NEW `aws-resources.yaml` file containing 5 cluster-scoped AWS resources (Bucket + User + Policy + UserPolicyAttachment + AccessKey).

## Why this approach (Option B)

v1.3 attempted to have the Crossplane Composition emit cluster-scoped AWS resources directly. Crossplane v2 enforces a strict scope-mismatch check — namespaced XApplication XR cannot compose cluster-scoped resources. v1.3.1 pivots to **raw manifests via the scaffolder**, matching the existing `loki-aws-infrastructure/` and `argo-workflows-aws-infrastructure/` patterns proven on this cluster.

## Changes

| Change | File | Why |
|---|---|---|
| Add `bucketName` to `fetch.values` mapping | `examples/templates/application/template.yaml` | Computed value used by aws-resources.yaml for both bucket name and IAM Policy ARNs |
| Create new content-k8s file with 5 AWS resources | `examples/templates/application/content-k8s/base-apps/${{ values.name }}/aws-resources.yaml` | Nunjucks-conditional on s3Needed:true; multi-doc YAML; each resource has TeraSky annotations + selector labels |

## Cross-resource references

UserPolicyAttachment uses `policyArnSelector.matchLabels` (resolves Policy by labels) + `userRef.name` (resolves User by name). AccessKey uses `userSelector.matchLabels`. Crossplane resolves these at apply time — no hard ARN references; no sync waves needed.

## Test plan

- [ ] After Backstage image rebuild, scaffold an app with `s3Needed:true` — verify PR has 3 files (smoke-v131.yaml, application-xr.yaml, **aws-resources.yaml** with 5 AWS resources)
- [ ] Default behavior (`s3Needed:false`): scaffold PR has 2 files (no aws-resources.yaml; Backstage skips empty file)

## Image rebuild needed?

Yes. After this merges, the Backstage image needs to be rebuilt and `base-apps/backstage/deployments.yaml` tag bumped (or tag reused + pod relaunched, like v1.2.1 / v1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)