### PR TITLE
fix(scaffolder): correct PR body text Retain → None (v1.5.1)

### DIFF
--- a/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts
+++ b/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts
@@ -53,7 +53,7 @@ function buildPrBody(name: string): string {
     '## Manual Vault cleanup (v1.5)',
     '',
     'PushSecret entries in Vault are NOT auto-deleted (v1.5 changed',
-    'deletionPolicy: Delete → Retain to fix a teardown race). After',
+    'deletionPolicy: Delete → None to fix a teardown race). After',
     'namespace deletion, run:',
     '',
     '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db-creds',


### PR DESCRIPTION
## Summary
Companion to arigsela/kubernetes#257. v1.5's \`buildPrBody\` explanation said \"deletionPolicy: Delete → Retain\" but ESO v0.11.0's PushSecret CRD enum is actually \`[\"Delete\", \"None\"]\` — \`Retain\` doesn't exist on this cluster's ESO version. The cluster-side Composition is being hotfixed to use \`None\`; this PR keeps the PR-body explanation in sync.

## Diff
\`\`\`diff
-    'deletionPolicy: Delete → Retain to fix a teardown race). After',
+    'deletionPolicy: Delete → None to fix a teardown race). After',
\`\`\`

One word. One line.

## Test impact
None. The \`happy_path\` test assertions check:
- \`stringContaining('Manual Vault cleanup (v1.5)')\` — unchanged
- \`stringContaining('vault kv delete k8s-secrets/smoke-v141/db-creds')\` — unchanged
- \`stringContaining('vault kv delete k8s-secrets/smoke-v141/aws-creds')\` — unchanged

The explanation text being changed is not asserted by any test. All 7 unit tests remain valid without modification.

## Companion PR
- arigsela/kubernetes#257 — flips the actual Composition + render-test goldens from \"Retain\" to \"None\"

After merge: rebuild Backstage image so the new PR body text ships with future teardown PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)