### PR TITLE
fix(scaffolder): correct Vault path for DB cleanup command (v1.5.2)

### DIFF
--- a/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.test.ts
+++ b/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.test.ts
@@ -132,7 +132,7 @@ describe('crossplane:teardown:open-decommission-pr', () => {
       body: expect.stringContaining('Manual Vault cleanup (v1.5)'),
     }));
     expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
-      body: expect.stringContaining('vault kv delete k8s-secrets/smoke-v141/db-creds'),
+      body: expect.stringContaining('vault kv delete k8s-secrets/smoke-v141/db'),
     }));
     expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
       body: expect.stringContaining('vault kv delete k8s-secrets/smoke-v141/aws-creds'),

--- a/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts
+++ b/packages/backend/src/modules/scaffolder/decommissionPullRequestAction.ts
@@ -56,7 +56,7 @@ function buildPrBody(name: string): string {
     'deletionPolicy: Delete → None to fix a teardown race). After',
     'namespace deletion, run:',
     '',
-    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db-creds',
+    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db',
     '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/aws-creds',
     '',
     'Skip whichever entry does not exist (an app without dbNeeded won\'t',


### PR DESCRIPTION
## Summary
v1.5/v1.5.1's \`buildPrBody\` advertised the DB Vault cleanup path as \`k8s-secrets/<name>/db-creds\` but the Composition (unchanged since v1.2) actually writes DB credentials to \`k8s-secrets/<name>/db\`. Verified against live \`smoke-v15\` cluster:

\`\`\`
$ vault kv list k8s-secrets/smoke-v15
Keys
----
aws-creds
db
\`\`\`

\`db\` — not \`db-creds\`.

## Diff
\`\`\`diff
-    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db-creds',
+    '  kubectl exec -n vault vault-0 -- vault kv delete k8s-secrets/' + name + '/db',
\`\`\`

Plus the matching test assertion update.

## Impact
Advisory-text bug only — the v1.5 core fix (\`deletionPolicy: None\`) works correctly. Operators following the old PR body would have hit \`No value found\` on the wrong path and needed to discover \`/db\` themselves.

## Test plan
- [x] Test assertion updated to match (\`stringContaining('vault kv delete k8s-secrets/smoke-v141/db')\`)
- [ ] After image rebuild + redeploy, the next teardown PR body will show the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)