### PR TITLE
feat(kagent-idp-v1.7): 'About this agent' entity card + scaffolder template

### DIFF
--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -1,3 +1,11 @@
+{%- set delegate_descriptions = {
+    "k8s-agent": "Kubernetes cluster operations (pods, deployments, RBAC, troubleshooting)",
+    "helm-agent": "Helm release lifecycle (install/upgrade/rollback, chart inspection)",
+    "istio-agent": "Istio service-mesh configuration and traffic management",
+    "kgateway-agent": "Kubernetes Gateway API (kgateway/Envoy)",
+    "argo-rollouts-conversion-agent": "Convert Deployments to Argo Rollouts for progressive delivery",
+    "observability-agent": "Prometheus + Grafana metrics and dashboard management"
+} -%}
 apiVersion: kagent.dev/v1alpha2
 kind: Agent
 metadata:
@@ -11,6 +19,59 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
     backstage.io/owner: ${{ values.owner }}
+    arigsela.com/kagent-about: |
+      # ${{ values.name }}
+
+      ${{ values.description }}
+
+      ## Purpose
+
+      ${{ values.systemMessage | replace('\n', '\n      ') }}
+{%- if values.skills | length > 0 %}
+
+      ## Skills
+{%- for skill in values.skills %}
+
+      ### ${{ skill.name }} (`${{ skill.id }}`)
+
+      ${{ skill.description }}
+{%- if skill.examples and skill.examples | length > 0 %}
+
+      **Examples:**
+{%- for example in skill.examples %}
+      - ${{ example }}
+{%- endfor %}
+{%- endif %}
+{%- if skill.tags and skill.tags | length > 0 %}
+
+      **Tags:** {% for tag in skill.tags %}`${{ tag }}`{% if not loop.last %}, {% endif %}{% endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+
+      ## Delegates to
+
+      This agent can delegate tasks to the following agents:
+{%- for agentName in values.delegateAgents %}
+      - **${{ agentName }}** — {{ delegate_descriptions[agentName] or "(see kagent docs)" }}
+{%- endfor %}
+
+      ## Configuration
+
+      | Setting | Value |
+      |---|---|
+      | Model | `default-model-config` |
+      | Memory model | `embedding-model-config` |
+      | Compaction interval | ${{ values.compactionInterval }} turns |
+      | Compaction overlap | ${{ values.overlapSize }} turns |
+      | CPU | ${{ values.cpuRequest }} / ${{ values.cpuLimit }} (req/lim) |
+      | Memory | ${{ values.memoryRequest }} / ${{ values.memoryLimit }} (req/lim) |
+      | Built-in prompts | {% if values.includeBuiltinPrompts %}included{% else %}not included{% endif %} |
+
+      ## Manage
+
+      - **Edit:** hand-edit `base-apps/kagent/agents/${{ values.name }}.yaml` and open a PR
+      - **Decommission:** use the **Decommission Kagent Agent** template in Backstage
 spec:
   description: ${{ values.description }}
   type: Declarative

--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -19,7 +19,7 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
     backstage.io/owner: ${{ values.owner }}
-    arigsela.com/kagent-about: |
+    terasky.backstage.io/kagent-about: |
       # ${{ values.name }}
 
       ${{ values.description }}

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -27,6 +27,7 @@ import {
   hasRelationWarnings,
   EntityRelationWarning,
 } from '@backstage/plugin-catalog';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import {
   EntityUserProfileCard,
   EntityGroupProfileCard,
@@ -34,12 +35,13 @@ import {
   EntityOwnershipCard,
 } from '@backstage/plugin-org';
 import { EntityTechdocsContent } from '@backstage/plugin-techdocs';
-import { EmptyState } from '@backstage/core-components';
+import { EmptyState, InfoCard, MarkdownContent } from '@backstage/core-components';
 import {
   Direction,
   EntityCatalogGraphCard,
 } from '@backstage/plugin-catalog-graph';
 import {
+  Entity,
   RELATION_API_CONSUMED_BY,
   RELATION_API_PROVIDED_BY,
   RELATION_CONSUMES_API,
@@ -72,6 +74,46 @@ const techdocsContent = (
       <ReportIssue />
     </TechDocsAddons>
   </EntityTechdocsContent>
+);
+
+// =============================================================================
+// Kagent IDP v1.7 — "About this agent" card
+// =============================================================================
+// Renders the pre-baked arigsela.com/kagent-about annotation on the Overview
+// tab for entities with spec.type = 'kagent-agent'. Returns null for any other
+// entity type or when the annotation is absent (e.g. older agents not yet
+// backfilled).
+//
+// Pattern: EntitySwitch outside, Grid item INSIDE the matching case. This is
+// the convention `entityWarningContent` uses below — keeps the Grid container
+// flat for non-matching entities (no empty Grid item leaks).
+//
+// Companion spec: arigsela/kubernetes:docs/superpowers/specs/2026-05-18-kagent-idp-v1.7-design.md
+
+const KAGENT_ABOUT_ANNOTATION = 'arigsela.com/kagent-about';
+
+const isKagentAgent = (entity: Entity): boolean =>
+  entity?.spec?.type === 'kagent-agent';
+
+const KagentAboutCardContent = () => {
+  const { entity } = useEntity();
+  const about = entity.metadata.annotations?.[KAGENT_ABOUT_ANNOTATION];
+  if (!about) return null;
+  return (
+    <Grid item xs={12}>
+      <InfoCard title="About this agent">
+        <MarkdownContent content={about} />
+      </InfoCard>
+    </Grid>
+  );
+};
+
+const kagentAboutCard = (
+  <EntitySwitch>
+    <EntitySwitch.Case if={isKagentAgent}>
+      <KagentAboutCardContent />
+    </EntitySwitch.Case>
+  </EntitySwitch>
 );
 
 const cicdContent = (
@@ -141,6 +183,8 @@ const overviewContent = (
     <Grid item md={6} xs={12}>
       <EntityCatalogGraphCard variant="gridItem" height={400} />
     </Grid>
+
+    {kagentAboutCard}
 
     <Grid item md={4} xs={12}>
       <EntityLinksCard />

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -79,7 +79,7 @@ const techdocsContent = (
 // =============================================================================
 // Kagent IDP v1.7 — "About this agent" card
 // =============================================================================
-// Renders the pre-baked arigsela.com/kagent-about annotation on the Overview
+// Renders the pre-baked terasky.backstage.io/kagent-about annotation on the Overview
 // tab for entities with spec.type = 'kagent-agent'. Returns null for any other
 // entity type or when the annotation is absent (e.g. older agents not yet
 // backfilled).
@@ -90,7 +90,7 @@ const techdocsContent = (
 //
 // Companion spec: arigsela/kubernetes:docs/superpowers/specs/2026-05-18-kagent-idp-v1.7-design.md
 
-const KAGENT_ABOUT_ANNOTATION = 'arigsela.com/kagent-about';
+const KAGENT_ABOUT_ANNOTATION = 'terasky.backstage.io/kagent-about';
 
 const isKagentAgent = (entity: Entity): boolean =>
   entity?.spec?.type === 'kagent-agent';


### PR DESCRIPTION
## Summary

Backstage v1.7 of the kagent IDP. Adds a rich per-agent view in Backstage by rendering a pre-baked Markdown summary as an "About this agent" InfoCard on the entity Overview tab.

The scaffolder bakes the summary into a single annotation (`arigsela.com/kagent-about`) at scaffold time; a small EntitySwitch.Case in `EntityPage.tsx` reads the annotation via the `useEntity()` hook and renders it through `MarkdownContent`. Card is only visible for entities with `spec.type='kagent-agent'`; non-matching entities and older agents without the annotation render nothing (no broken UI).

Companion spec + plan: `arigsela/kubernetes:docs/superpowers/specs/2026-05-18-kagent-idp-v1.7-design.md` (will be pushed in a separate docs PR).

## Changes

### `packages/app/src/components/catalog/EntityPage.tsx`

- New imports: `InfoCard`, `MarkdownContent` from `@backstage/core-components` (existing dep); `Entity` from `@backstage/catalog-model`; `useEntity` from `@backstage/plugin-catalog-react`.
- New `KAGENT_ABOUT_ANNOTATION` constant + `isKagentAgent` predicate.
- New `KagentAboutCardContent` component that pulls the annotation and renders it.
- New `kagentAboutCard` JSX (`EntitySwitch` wrapping the case + content).
- Injects `{kagentAboutCard}` into `overviewContent` after the `EntityCatalogGraphCard` block — matches the existing `entityWarningContent` injection pattern (EntitySwitch outside, Grid item inside the matching case).

### `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml`

- Adds a Nunjucks `{% set delegate_descriptions = {...} %}` block at the top with human-readable descriptions for each of the 6 chart-installed agents the wizard can delegate to.
- Adds the `arigsela.com/kagent-about` annotation under `metadata.annotations` containing a Markdown body with sections: Purpose (full systemMessage), Skills (per skill: name, id, description, examples, tags), Delegates to (with descriptions), Configuration (table), Manage (operator actions).
- Uses `${{ values.systemMessage | replace('\n', '\n      ') }}` for the systemMessage rather than `| indent(6)` — fixes the v1.6 pitfall where `indent()` added extra spaces on continuation lines.

## What this does NOT change

- The kagent CRD schema (annotation is pure operator metadata, ignored by the kagent controller)
- Any of the existing custom scaffolder actions (`kagent:agent:validate-name`, `kagent:agent:open-decommission-pr`)
- `app-config.yaml` or `app-config.production.yaml` (no new templates, no new locations)
- Any other entity types' pages (the `EntitySwitch.Case` predicate ensures only kagent agents see the card)

## Test plan

- [x] `yarn tsc` passes (clean)
- [x] Standalone Nunjucks render + YAML parse pre-flight check passes — confirms the template generates valid YAML with all expected sections (Purpose, Skills, Delegates to, Configuration, Manage), correct delegate descriptions for `k8s-agent`/`helm-agent`, and consistent 6-space indent on multi-line `systemMessage` continuation lines
- [ ] After image rebuild + redeploy: visit a kagent-agent entity at `https://backstage.arigsela.com/catalog/default/component/homelab-knowledge` and verify the card renders (requires companion backfill PR in arigsela/kubernetes to first add the annotation to the existing agent)
- [ ] Negative check: any non-kagent Component entity shows no card

## Coordination with arigsela/kubernetes

A follow-up PR in `arigsela/kubernetes` will hand-backfill the `arigsela.com/kagent-about` annotation on the existing `homelab-knowledge.yaml` so the working agent gets the rich card immediately (rather than needing decommission + re-scaffold). The Backstage change is safe to deploy first — the card returns `null` when the annotation is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)