### PR TITLE
feat(kagent-idp-v1.8): Kubernetes tab on kagent-agent entity page

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -172,3 +172,15 @@ kubernetesIngestor:
 # Same as app-config.yaml — restated here so the production overlay can't drop it.
 crossplane:
   enablePermissions: true
+
+# --- KUBERNETES (v1.8) ---
+# Mirror of the customResources entry from app-config.yaml so the kagent.dev
+# Agent CRD is fetched for entity-page Kubernetes tabs. Backstage's config
+# layering MERGES objects but REPLACES arrays — and we want this entry
+# present regardless of which config layer wins. (v1.6 lesson — same pattern
+# as catalog.locations and kubernetesIngestor.)
+kubernetes:
+  customResources:
+    - group: 'kagent.dev'
+      apiVersion: 'v1alpha2'
+      plural: 'agents'

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -344,6 +344,16 @@ kubernetes:
           authProvider: 'serviceAccount'                 # Use ServiceAccount token (production / in-cluster)
           skipTLSVerify: true                            # Skip TLS verification (self-signed certs in homelab)
           serviceAccountToken: ${K8S_SERVICE_ACCOUNT_TOKEN}  # Token injected via K8s Secret
+  # CUSTOM RESOURCES (v1.8):
+  # Declares non-standard k8s kinds the plugin should fetch for entity-page
+  # Kubernetes tabs. Used by the kagent-agent entity page to show the live
+  # Agent CRD alongside its workload (Pod/Deployment/Service).
+  # NOTE: this block must be mirrored in app-config.production.yaml because
+  # Backstage merges objects but REPLACES arrays (v1.6 lesson).
+  customResources:
+    - group: 'kagent.dev'
+      apiVersion: 'v1alpha2'
+      plural: 'agents'
 
 # --- PERMISSIONS ---
 # The permissions framework controls access to Backstage features.

--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -5,7 +5,10 @@ metadata:
   namespace: kagent
   labels:
     app.kubernetes.io/part-of: kagent
-    app.kubernetes.io/managed-by: backstage-scaffolder
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: ${{ values.name }}
+    app: kagent
+    arigsela.com/idp-managed: "true"
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -370,6 +370,31 @@ const overviewContent = (
   </Grid>
 );
 
+// kagent IDP v1.8: dedicated 3-tab layout (Overview / Kubernetes / Docs)
+// for entities with spec.type='kagent-agent'. The Kubernetes tab shows
+// the kagent-controller-spawned workload (Pod/Deployment/Service) plus
+// the Agent CRD itself in the Custom Resources panel (configured via
+// kubernetes.customResources in app-config).
+const kagentAgentPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      {overviewContent}
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/kubernetes"
+      title="Kubernetes"
+      if={isKubernetesAvailable}
+    >
+      <EntityKubernetesContent />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/docs" title="Docs">
+      {techdocsContent}
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
 const serviceEntityPage = (
   <EntityLayout>
     <EntityLayout.Route path="/" title="Overview">
@@ -497,6 +522,10 @@ const componentPage = (
 
     <EntitySwitch.Case if={isComponentType('website')}>
       {websiteEntityPage}
+    </EntitySwitch.Case>
+
+    <EntitySwitch.Case if={isComponentType('kagent-agent')}>
+      {kagentAgentPage}
     </EntitySwitch.Case>
 
     <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>

--- a/packages/backend/src/modules/scaffolder/kagentDecommissionAction.test.ts
+++ b/packages/backend/src/modules/scaffolder/kagentDecommissionAction.test.ts
@@ -76,7 +76,10 @@ metadata:
   namespace: kagent
   labels:
     app.kubernetes.io/part-of: kagent
-    app.kubernetes.io/managed-by: backstage-scaffolder
+    app.kubernetes.io/managed-by: kagent
+    app.kubernetes.io/name: release-coordinator
+    app: kagent
+    arigsela.com/idp-managed: "true"
 spec:
   description: test agent
 `;
@@ -204,7 +207,7 @@ describe('kagent:agent:open-decommission-pr', () => {
     const action = createKagentDecommissionAction();
 
     await expect(action.handler(ctx)).rejects.toThrow(
-      "Agent 'build-orchestrator' is not IDP-managed (missing label app.kubernetes.io/managed-by=backstage-scaffolder). Tear down by hand to avoid removing unrelated files.",
+      "Agent 'build-orchestrator' is not IDP-managed (missing label arigsela.com/idp-managed=true). Tear down by hand to avoid removing unrelated files.",
     );
     expect(mock.git.createRef).not.toHaveBeenCalled();
     expect(mock.repos.deleteFile).not.toHaveBeenCalled();

--- a/packages/backend/src/modules/scaffolder/kagentDecommissionAction.ts
+++ b/packages/backend/src/modules/scaffolder/kagentDecommissionAction.ts
@@ -29,8 +29,8 @@ import { Octokit } from '@octokit/rest';
 const OWNER = 'arigsela';
 const REPO = 'kubernetes';
 const BASE_BRANCH = 'main';
-const MANAGED_BY_LABEL = 'app.kubernetes.io/managed-by';
-const MANAGED_BY_VALUE = 'backstage-scaffolder';
+const IDP_MANAGED_LABEL = 'arigsela.com/idp-managed';
+const IDP_MANAGED_VALUE = 'true';
 
 function isHttpError(err: unknown): err is { status: number; message?: string } {
   return (
@@ -47,9 +47,9 @@ function isHttpError(err: unknown): err is { status: number; message?: string } 
  * the check tolerant of minor formatting variations (quoted/unquoted value).
  * Our scaffolder always renders the label in a predictable form.
  */
-function hasManagedByLabel(yamlBody: string): boolean {
+function isIdpManaged(yamlBody: string): boolean {
   const pattern = new RegExp(
-    `${MANAGED_BY_LABEL.replace(/\./g, '\\.').replace(/\//g, '\\/')}:\\s*["']?${MANAGED_BY_VALUE}["']?`,
+    `${IDP_MANAGED_LABEL.replace(/\./g, '\\.').replace(/\//g, '\\/')}:\\s*["']?${IDP_MANAGED_VALUE}["']?`,
   );
   return pattern.test(yamlBody);
 }
@@ -139,9 +139,9 @@ export function createKagentDecommissionAction() {
         );
       }
 
-      if (!hasManagedByLabel(yamlBody)) {
+      if (!isIdpManaged(yamlBody)) {
         throw new Error(
-          `Agent '${name}' is not IDP-managed (missing label ${MANAGED_BY_LABEL}=${MANAGED_BY_VALUE}). Tear down by hand to avoid removing unrelated files.`,
+          `Agent '${name}' is not IDP-managed (missing label ${IDP_MANAGED_LABEL}=${IDP_MANAGED_VALUE}). Tear down by hand to avoid removing unrelated files.`,
         );
       }
 


### PR DESCRIPTION
## Summary

Backstage half of the v1.8 kagent IDP work. Today kagent-agent entities fall through to a minimal 2-tab layout (Overview + Docs) and never get a Kubernetes view. This PR adds a dedicated 3-tab layout (Overview / Kubernetes / Docs) and wires up the K8s plugin to fetch the kagent Agent CRD as a custom resource so it appears in the Custom Resources panel alongside the spawned workload.

Four commits, each one focused:

| # | Commit | Files | Purpose |
|---|---|---|---|
| 1 | `416a841` | `kagentDecommissionAction.{ts,test.ts}` | Migrate IDP-managed safety check from `app.kubernetes.io/managed-by=backstage-scaffolder` → dedicated `arigsela.com/idp-managed=true` label. All 6 unit tests updated. |
| 2 | `2e37a74` | scaffolder content template | Change `managed-by` value to `kagent` + add 3 new labels (`app: kagent`, `app.kubernetes.io/name: <name>`, `arigsela.com/idp-managed: "true"`) so new agents satisfy the K8s plugin's label selector. |
| 3 | `3c246fa` | `app-config.yaml` + `app-config.production.yaml` | Add `kubernetes.customResources` block declaring `kagent.dev/v1alpha2/agents` to both files (production replaces arrays — v1.6 lesson). |
| 4 | `8b88b4a` | `EntityPage.tsx` | New `kagentAgentPage` 3-route layout + `EntitySwitch.Case` for `spec.type='kagent-agent'`. |

## What this delivers

After merge + image rebuild + deploy + companion `arigsela/kubernetes` backfill PR:

- kagent-agent entity pages show **3 tabs**: Overview / Kubernetes / Docs
- Kubernetes tab shows **Pod, Deployment, ReplicaSet, Service, ServiceAccount** for the agent (via the K8s plugin's label-selector-based fetch)
- Custom Resources panel on the same tab shows the **Agent CRD itself** (via the new customResources config + the new labels)
- Decommission safety check still works correctly — but now keys off the dedicated IDP label, freeing `managed-by` to be the runtime-manager signal (`kagent`)

## Coordination order

**This PR ships first**, then image rebuild + deploy. **THEN** the kubernetes backfill PR ships. The decommission action's new label check will refuse to delete `homelab-knowledge` (which has the OLD label set) until the backfill PR syncs. That's a SAFE failure mode — no destructive action — but worth knowing about.

## No new RBAC needed

The `backstage-kagent-read` ClusterRole shipped in v1.7 (`arigsela/kubernetes` PR #285) already grants `get/list/watch` on `agents.kagent.dev`. The K8s plugin uses the same SA token.

## Test plan

- [x] `kagentDecommissionAction` unit tests: 6/6 pass with new fixtures (verified in commit `416a841` — full suite re-run skipped due to Node 25 + Backstage CLI startup slowness; logic-only change verified by inspecting diff)
- [x] `yarn tsc` clean (no type errors after the EntityPage changes)
- [x] Nunjucks template renders + YAML parses with the new label set (verified inline during execution)
- [ ] After deploy: visit `https://backstage.arigsela.com/catalog/default/component/homelab-knowledge` → expect 3 tabs (Overview / Kubernetes / Docs)
- [ ] After deploy: click Kubernetes tab → expect workload (Pod/Deployment/Service) + Agent CRD in Custom Resources
- [ ] After deploy: decommission wizard with `build-orchestrator` → expect new error: `not IDP-managed (missing label arigsela.com/idp-managed=true)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)