### PR TITLE
feat(kagent): K8s entity tab + agents.platform.ai v1 contract

### DIFF
--- a/docs/guides/agent-annotation-contract-v1.md
+++ b/docs/guides/agent-annotation-contract-v1.md
@@ -1,0 +1,71 @@
+# Agent Annotation Contract — v1
+
+> Companion to the kagent-agent scaffolder template. Documents the
+> `agents.platform.ai/*` annotations that every IDP-managed kagent
+> Agent carries in both its K8s CRD and its Backstage catalog entity.
+>
+> Design spec: `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`
+
+## Purpose
+
+Make kagent agents queryable as a first-class, structured concept in
+the Backstage catalog so that MCP-backed assistants and scorecard
+checks can read them via the catalog API alone, without a second K8s
+API hop.
+
+## Where the contract lives
+
+- **Source of truth:** `metadata.annotations` on the rendered
+  `kagent.dev/v1alpha2` Agent CRD in `arigsela/kubernetes`.
+- **Catalog mirror:** TeraSky's `kubernetes-ingestor` copies the
+  annotations 1:1 onto the resulting `kind: Component, spec.type: kagent-agent`
+  entity in the Backstage catalog.
+- **Query:** `GET /api/catalog/entities?filter=kind=Component,spec.type=kagent-agent`
+
+## Fields (v1)
+
+| Annotation | Type | Required | Description |
+| --- | --- | --- | --- |
+| `agents.platform.ai/version` | string (`"v1"`) | yes | Contract version. Consumers must reject unknown versions. |
+| `agents.platform.ai/runtime` | string (`kagent`) | yes | Runtime that hosts this agent. Discriminator for future multi-runtime support. |
+| `agents.platform.ai/description` | string | yes | Human-readable one-liner, ≤200 chars. |
+| `agents.platform.ai/a2a-endpoint` | URL | yes | Where to call this agent (A2A protocol). For kagent: `http://<name>.kagent.svc.cluster.local:8080`. |
+| `agents.platform.ai/skills` | JSON array | yes (may be `[]`) | A2A skills: `[{id,name,description,examples?,tags?}, …]` |
+| `agents.platform.ai/delegates` | JSON array of strings | yes (may be `[]`) | Peer agent names this agent is allowed to call. |
+| `agents.platform.ai/capabilities` | JSON object | yes | Capability flags. For kagent v1: `{"streaming":true,"a2a":true}`. |
+
+## Consumers (reader code)
+
+The minimum reader code to enumerate agents from the catalog:
+
+```bash
+curl -s "$BACKSTAGE_URL/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent" \
+  | jq '.[] | {
+      name: .metadata.name,
+      desc: .metadata.annotations["agents.platform.ai/description"],
+      endpoint: .metadata.annotations["agents.platform.ai/a2a-endpoint"],
+      skills: (.metadata.annotations["agents.platform.ai/skills"] | fromjson),
+      delegates: (.metadata.annotations["agents.platform.ai/delegates"] | fromjson)
+    }'
+```
+
+## Validation tools
+
+- **Offline (Layer 1):** `bash scripts/kagent-template/test-contract.sh`
+- **Live catalog (Layer 3):** `BACKSTAGE_URL=https://backstage.arigsela.com BACKSTAGE_TOKEN=<optional> bash scripts/check-agent-contract.sh` *(Layer 2 — live ingestion correctness — is operator-driven and not automatable; see the design spec.)*
+
+## Forward compatibility
+
+The v1 namespace and shape were chosen to migrate cleanly to the
+upstream `kind: AIContext` proposal (RFC #33575) when it ships. The
+migration path and field mapping are documented in the design spec.
+
+## Future versions
+
+Anticipated v2 additions (not implemented):
+
+- `agents.platform.ai/system-message-digest` — change detection
+- `agents.platform.ai/disciplines` — when MCP routing needs discipline-aware selection
+- `agents.platform.ai/categories` — when group-by-category becomes useful
+
+Adding v2 fields will bump `agents.platform.ai/version` to `"v2"`. Consumers should default-reject unknown versions rather than ignoring fields they don't understand.

--- a/docs/plans/auto-discovery-contract-implementation-plan.md
+++ b/docs/plans/auto-discovery-contract-implementation-plan.md
@@ -1,0 +1,264 @@
+# Auto-Discovery Contract for Backstage CrewAI Template
+
+## Overview
+
+**Goal:** Make any scaffolded orchestrator automatically discoverable by a shared frontend. Three changes enable this: K8s Service discovery labels, standardized `/info` response with capabilities, and (optionally) CopilotKit streaming support.
+
+**LEVER Analysis:**
+- **Leverage:** Existing ConfigMap pattern, `/info` endpoint, template parameter passing
+- **Extend:** Service labels (+2 lines), `/info` response (+5 fields), ConfigMap (+2 vars)
+- **Verify:** Dry-run render, curl `/info`, frontend integration test
+- **Eliminate:** No duplication — reuses existing config patterns
+- **Reduce:** Phase 1+2 are ~15 lines across 4 files
+
+**Estimated Code Impact:** ~25 lines added/modified for Phase 1+2, ~100 lines for Phase 3
+
+---
+
+## Related work
+
+- **`agents.platform.ai/*` v1 contract** — kagent agents emit a structured annotation contract for MCP and scorecard consumers. See `docs/guides/agent-annotation-contract-v1.md` and the design spec at `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`. This and the auto-discovery contract are intentionally orthogonal: the auto-discovery contract describes how a frontend finds *running* orchestrators via K8s Service labels; the agent annotation contract describes how MCP enumerates *catalog-registered* agents.
+
+---
+
+## Architecture
+
+### Discovery Flow
+```
+Frontend → kubectl get svc -l platform.ai/component=orchestrator → List of Services
+         → For each Service: GET /info → { displayName, description, capabilities }
+         → Render UI: dropdown with orchestrators, adapt chat mode per capabilities
+```
+
+### Capabilities Contract
+```json
+{
+  "service": "my-agent",
+  "role": "orchestrator",
+  "displayName": "My Agent",
+  "description": "What this agent does",
+  "capabilities": {
+    "copilotkit": false,
+    "invoke": true
+  },
+  "sub_agents": [...]
+}
+```
+
+- `copilotkit: true` → Full AG-UI SSE streaming chat
+- `invoke: true` only → Simple request/response chat wrapper
+
+---
+
+## Phase 1: K8s Service Discovery Labels
+**Effort:** ~5 min | **Risk:** Very low (additive only)
+
+### Files Modified
+| File | Change |
+|------|--------|
+| `content-k8s/.../orchestrator/deployment.yaml` | Add 2 labels to Service metadata |
+
+### Task 1.1: Add Discovery Labels to Orchestrator Service ✅
+
+**File:** `examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/deployment.yaml`
+
+Added `platform.ai/component: orchestrator` and `platform.ai/display-name: ${{ values.name }}` labels to the Service metadata (lines 164-167).
+
+### Task 1.2: Verify Dry-Run Output ✅
+
+Verified via cluster inspection on 2026-03-09. The DnD agent (scaffolded before the template change) does not have the labels, confirming labels are template-rendered at scaffold time. New agents scaffolded from the updated template will get them automatically.
+
+**Note:** Existing agents (dnd-agent, oncall-crewai) need their K8s Service labels added manually in the `arigsela/kubernetes` repo if they should be discoverable.
+
+### Phase 1 Summary
+✅ Complete | Tasks: 2/2 (100%)
+
+---
+
+## Phase 2: Standardize /info Endpoint Response
+**Effort:** ~30 min | **Risk:** Low (additive, backward-compatible)
+
+### Files Modified
+| File | Change |
+|------|--------|
+| `content-agent/src/shared/config.py` | Add DISPLAY_NAME, DESCRIPTION env var parsing |
+| `content-agent/src/orchestrator/main.py` | Extend /info response with new fields |
+| `content-k8s/.../orchestrator/configmap.yaml` | Add 2 new env vars |
+
+### Task 2.1: Add Config Variables ✅
+
+**File:** `examples/templates/crewai-agent/content-agent/src/shared/config.py`
+
+Added `DISPLAY_NAME` and `DESCRIPTION` env var parsing after `PROJECT_NAME` (lines 31-35).
+
+### Task 2.2: Add ConfigMap Entries ✅
+
+**File:** `examples/templates/crewai-agent/content-k8s/base-apps/oncall-crewai/${{ values.name }}/orchestrator/configmap.yaml`
+
+Added `ORCHESTRATOR_DISPLAY_NAME` and `ORCHESTRATOR_DESCRIPTION` entries (lines 33-36).
+
+### Task 2.3: Extend /info Endpoint Response ✅
+
+**File:** `examples/templates/crewai-agent/content-agent/src/orchestrator/main.py`
+
+Extended `/info` response with `displayName`, `description`, and `capabilities` object (lines 102-127). The `capabilities.copilotkit` value is template-conditional using `{% if values.enableCopilotKit %}`.
+
+### Task 2.4: Verify /info Contract ✅
+
+Verified live on the DnD agent orchestrator pod (2026-03-09). `curl localhost:8000/info` returned:
+```json
+{
+  "service": "dnd-agent",
+  "role": "orchestrator",
+  "displayName": "dnd-agent",
+  "description": "",
+  "capabilities": {
+    "copilotkit": true,
+    "invoke": true
+  },
+  "sub_agents": [
+    {
+      "name": "dnd-character-agent",
+      "url": "http://dnd-agent-dnd-character-agent.oncall-crewai.svc:8080",
+      "keywords": ["dnd", "dungeons", "dragons", "adventure"]
+    }
+  ]
+}
+```
+
+All new fields present and correct. `description` is empty because the DnD agent's ConfigMap was created before the `ORCHESTRATOR_DESCRIPTION` env var was added.
+
+### Phase 2 Summary
+✅ Complete | Tasks: 4/4 (100%)
+
+---
+
+## Phase 3: CopilotKit Streaming Support
+**Effort:** ~1 day | **Risk:** Medium (new dependency, new protocol)
+
+### Prerequisites
+- ✅ Research AG-UI SSE protocol specification
+- ✅ Identify CopilotKit Python SDK (`copilotkit[crewai]` on PyPI, v0.1.78+)
+- ✅ Determine bridge approach — ended up using `ag-ui-protocol` directly (see Implementation Notes)
+
+### Files Modified
+| File | Change |
+|------|--------|
+| `template.yaml` | Add `enableCopilotKit` boolean parameter + pass to both fetch steps |
+| `content-agent/src/orchestrator/main.py` | Conditional import and mount of CopilotKit handler |
+| `content-agent/src/orchestrator/copilotkit_handler.py` | **New file** — AG-UI SSE streaming endpoint |
+| `content-agent/requirements.txt` | Add `ag-ui-protocol>=0.1.0` (conditional) |
+
+### Task 3.1: Add Template Parameter ✅
+
+**File:** `examples/templates/crewai-agent/template.yaml`
+
+Added `enableCopilotKit` boolean parameter to "Orchestrator Configuration" page (lines 133-140). Passed to both `fetch:template` steps via `enableCopilotKit: ${{ parameters.enableCopilotKit }}`.
+
+### Task 3.2: Add CopilotKit Dependencies ✅
+
+**File:** `content-agent/requirements.txt`
+
+Added conditional `ag-ui-protocol>=0.1.0` dependency using `{%- if values.enableCopilotKit %}` Nunjucks block.
+
+**Evolution:** Originally used `copilotkit[crewai]`, then `copilotkit` (base), and finally `ag-ui-protocol` due to incompatibility with `crewai==1.6.1` (see Implementation Notes).
+
+### Task 3.3: Add /copilotkit Endpoint ✅
+
+**New file:** `content-agent/src/orchestrator/copilotkit_handler.py`
+
+Created AG-UI streaming handler using `ag-ui-protocol` directly:
+- `_run_orchestrator_flow(query)` — Runs OrchestratorFlow synchronously, returns (result, route)
+- `setup_copilotkit(app)` — Registers `POST /copilotkit` endpoint that bridges OrchestratorFlow to AG-UI SSE events via `asyncio.to_thread()`
+
+**File:** `content-agent/src/orchestrator/main.py`
+
+Added conditional import and mount at lines 77-84:
+```python
+{% if values.enableCopilotKit %}
+from orchestrator.copilotkit_handler import setup_copilotkit
+setup_copilotkit(app)
+{% endif %}
+```
+
+### Task 3.4: Update /info Capabilities ✅
+
+Already done in Task 2.3 — `capabilities.copilotkit` uses template-conditional `{% if values.enableCopilotKit %}True{% else %}False{% endif %}` (line 117).
+
+### Task 3.5: Integration Testing ✅
+
+Verified live on the DnD agent orchestrator pod (2026-03-09). Sent a POST to `/copilotkit` with a properly structured `RunAgentInput` payload and received a correct AG-UI SSE event stream:
+
+```
+data: {"type":"RUN_STARTED","threadId":"test-123","runId":"68f9662d-..."}
+data: {"type":"TEXT_MESSAGE_START","messageId":"3fff725e-...","role":"assistant"}
+data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"3fff725e-...","delta":"I'm not sure how to help with that specific request. I'm specialized in topics related to: dnd, dungeons, dragons, adventure. Could you rephrase your question or ask about one of these topics?"}
+data: {"type":"TEXT_MESSAGE_END","messageId":"3fff725e-..."}
+data: {"type":"RUN_FINISHED","threadId":"test-123","runId":"68f9662d-..."}
+```
+
+All 5 AG-UI lifecycle events present in correct order. The "hello" query correctly hit the no-match fallback (no DnD keywords matched), confirming the OrchestratorFlow routing works through the AG-UI streaming path.
+
+### Phase 3 Summary
+✅ Complete | Tasks: 5/5 (100%)
+
+---
+
+## Progress Tracker
+
+| Phase | Description | Tasks | Status |
+|-------|-------------|-------|--------|
+| 1 | K8s Discovery Labels | 2/2 (100%) | ✅ Complete |
+| 2 | Standardize /info Response | 4/4 (100%) | ✅ Complete |
+| 3 | CopilotKit Support | 5/5 (100%) | ✅ Complete |
+| **Total** | | **11/11 (100%)** | ✅ **ALL COMPLETE** |
+
+**Last Updated:** 2026-03-09
+**Current Status:** All phases implemented, deployed, and verified in production cluster.
+
+---
+
+## Implementation Notes
+
+### Design Decision: ag-ui-protocol instead of copilotkit Python SDK
+The `copilotkit` Python SDK imports `crewai.utilities.events.flow_events` which only exists in newer CrewAI versions. We're pinned to `crewai==1.6.1` (AVX2/LanceDB incompatibility on older CPUs — Intel E5-2670 Sandy Bridge nodes cause SIGILL exit code 132). The `ag-ui-protocol` package provides the same AG-UI SSE event types and encoder with zero CrewAI dependency — it only handles the SSE protocol layer. The CopilotKit frontend consumes the same SSE event stream regardless of which server-side library produces it.
+
+**Dependency evolution during implementation:**
+1. `copilotkit[crewai]>=0.1.70` — pip `ResolutionImpossible` (crewai version conflict)
+2. `copilotkit>=0.1.70` + `litellm>=1.30.0` — `ModuleNotFoundError: crewai.utilities.events` at runtime
+3. `ag-ui-protocol>=0.1.0` — works with `crewai==1.6.1`, zero conflicts
+
+### Design Decision: Template-Conditional vs Env Var for capabilities.copilotkit
+Chose **template-conditional** (`{% if values.enableCopilotKit %}True{% else %}False{% endif %}`) rather than an env var. Rationale: the CopilotKit endpoint is either present or absent in the generated code — it's a build-time decision, not a runtime toggle. Using a template conditional keeps it simple and avoids unused env vars.
+
+### Design Decision: Separate copilotkit_handler.py
+Isolated CopilotKit setup in a dedicated module rather than inline in main.py. Rationale:
+1. Keeps main.py clean — the conditional block is just 2 lines (import + call)
+2. Avoids importing `ag-ui-protocol` when it's not installed
+3. The handler has its own concerns (flow execution, SSE encoding) that warrant separation
+
+### AG-UI Integration Approach
+Used `ag-ui-protocol` directly to implement the AG-UI SSE event stream. The handler:
+1. Receives `RunAgentInput` from CopilotKit frontend
+2. Extracts the last user message as the query
+3. Runs `OrchestratorFlow.kickoff()` via `asyncio.to_thread()` (sync-to-async bridge)
+4. Emits the full result as AG-UI SSE events (RunStarted → TextMessage → RunFinished)
+
+**Limitation:** Since `OrchestratorFlow.kickoff()` is a blocking call, the result is emitted as a single `TextMessageContent` chunk (no token-level streaming). For true token streaming, CrewAI would need async callback hooks.
+
+### Remaining Manual Steps
+- **Existing agents** (dnd-agent, oncall-crewai) need `platform.ai/component: orchestrator` labels added manually to their K8s Service manifests in `arigsela/kubernetes` repo
+- **DnD agent ConfigMap** needs `ORCHESTRATOR_DESCRIPTION` added for the description to appear in `/info`
+- **Frontend discovery endpoint** still needs to be built to consume these labels and `/info` responses
+
+### Files Changed Summary
+| File | Phase | Lines Changed |
+|------|-------|---------------|
+| `content-k8s/.../orchestrator/deployment.yaml` | 1 | +4 (labels + comments) |
+| `content-agent/src/shared/config.py` | 2 | +4 (DISPLAY_NAME, DESCRIPTION) |
+| `content-k8s/.../orchestrator/configmap.yaml` | 2 | +4 (2 env vars + comments) |
+| `content-agent/src/orchestrator/main.py` | 2+3 | +18 (info fields, copilotkit mount) |
+| `template.yaml` | 3 | +11 (parameter + 2 fetch passthrough) |
+| `content-agent/requirements.txt` | 3 | +5 (conditional dep) |
+| `content-agent/src/orchestrator/copilotkit_handler.py` | 3 | +95 (new file, AG-UI handler) |
+| **Total** | | **~141 lines** |

--- a/docs/superpowers/plans/2026-05-19-aicontext-catalog-kind.md
+++ b/docs/superpowers/plans/2026-05-19-aicontext-catalog-kind.md
@@ -297,10 +297,33 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
 Now make the failing tests pass by adding the 7 annotations to the rendered CRD.
 
+Task 1's `full` fixture additionally surfaced a pre-existing YAML-escaping
+bug on the existing `spec.description` field — it is rendered as a plain
+scalar and breaks if the user's description contains a colon. This task
+also fixes that.
+
 **Files:**
 - Modify: `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml`
 
-- [ ] **Step 1: Add the annotations**
+- [ ] **Step 1a: Fix the existing `spec.description` quoting**
+
+The current file at line 18 has:
+
+```yaml
+spec:
+  description: ${{ values.description }}
+```
+
+Change line 18 to use a `|-` block scalar so user input containing `:`,
+newlines, or quotes can't break YAML parsing:
+
+```yaml
+spec:
+  description: |-
+    ${{ values.description }}
+```
+
+- [ ] **Step 1b: Add the new annotations**
 
 Edit the file. The existing `metadata.annotations` block is at lines 12–16. Insert 7 new annotations after `backstage.io/owner`, **before** the `spec:` block at line 17:
 
@@ -375,6 +398,11 @@ git commit -m "feat(kagent): emit agents.platform.ai/* v1 contract
 Adds 7 structured annotations to the rendered kagent Agent CRD so
 MCP-backed assistants can enumerate and call agents via the
 Backstage catalog API without a second K8s API hop.
+
+Also fixes a pre-existing YAML-escaping bug on spec.description: if a
+user's description contained ':' or newlines, the rendered CRD was
+invalid YAML. Switched to a |- block scalar to match the new annotation
+contract's escaping discipline.
 
 Layer 1 contract test (scripts/kagent-template/test-contract.sh)
 now passes. See docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md

--- a/docs/superpowers/plans/2026-05-19-aicontext-catalog-kind.md
+++ b/docs/superpowers/plans/2026-05-19-aicontext-catalog-kind.md
@@ -1,0 +1,652 @@
+# AIContext Catalog Modeling for kagent Agents — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the `kagent-agent` scaffolder template so every rendered Agent CRD carries a `agents.platform.ai/*` annotation contract that makes the agent queryable as a structured concept via the Backstage catalog API.
+
+**Architecture:** Single-file change to the rendered CRD template, JSON-encoded annotations via Nunjucks `| dump`, no new wizard parameters, no upstream upgrades. Verification via an offline Nunjucks render harness (Layer 1) plus a catalog-API contract reader script (Layer 3). Layer 2 (live ingestion correctness) is operator-driven once the change is deployed.
+
+**Tech Stack:** Backstage v1.48.0 scaffolder templates (Nunjucks), Node 25.x (already installed for Backstage), `yq` + `jq` (already installed on dev box) for shell assertions, Jest 30 (already a dev dep, used for the offline render test).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml` | Modify | Add 7 `agents.platform.ai/*` annotations to `metadata.annotations` |
+| `scripts/kagent-template/render.js` | Create | Standalone Node renderer for the kagent CRD Nunjucks template (used by Layer 1 tests) |
+| `scripts/kagent-template/fixtures/minimal.json` | Create | Fixture: minimum-valid wizard inputs (empty skills, empty delegates) |
+| `scripts/kagent-template/fixtures/full.json` | Create | Fixture: one skill with examples+tags, two delegates |
+| `scripts/kagent-template/test-contract.sh` | Create | Layer 1 test: renders each fixture, asserts 7 annotations + JSON shapes |
+| `scripts/check-agent-contract.sh` | Create | Layer 3 test: queries Backstage catalog API, validates annotations on live agents |
+| `docs/guides/agent-annotation-contract-v1.md` | Create | Public-facing contract docs for future MCP authors and scorecard authors |
+| `docs/plans/auto-discovery-contract-implementation-plan.md` | Modify | Add cross-reference to the new contract |
+
+**Why these boundaries:**
+- The renderer (`render.js`) and the fixture files are pure I/O — keeping them separate from the test logic lets us reuse the renderer in other contexts (e.g. a Jest test later, or a CI step).
+- `test-contract.sh` is the orchestrator. It's a shell script (not Jest) because the assertions are mostly YAML/JSON structural checks that `yq`/`jq` express more naturally than Jest matchers.
+- `check-agent-contract.sh` is the post-deploy mirror of the offline test, against the catalog API.
+- Documentation lives under `docs/guides/` (matches existing pattern in the repo).
+
+---
+
+## Task 1: Layer 1 offline render harness — write the failing test
+
+This task locks in the contract in machine-readable form **before** changing the template. The test will fail against today's template (no `agents.platform.ai/*` annotations); Task 2 makes it pass.
+
+**Files:**
+- Create: `scripts/kagent-template/render.js`
+- Create: `scripts/kagent-template/fixtures/minimal.json`
+- Create: `scripts/kagent-template/fixtures/full.json`
+- Create: `scripts/kagent-template/test-contract.sh`
+
+- [ ] **Step 1: Create the Nunjucks renderer**
+
+Create `scripts/kagent-template/render.js`:
+
+```javascript
+#!/usr/bin/env node
+// Offline renderer for the kagent-agent scaffolder template.
+// Usage: node render.js <fixture.json> > rendered.yaml
+//
+// Mirrors Backstage scaffolder's Nunjucks setup:
+//   - Custom variable tags: ${{ ... }} (not {{ ... }})
+//   - Custom `dump` filter that JSON-stringifies
+//   - Standard `trim`, `length`, `indent` filters from Nunjucks core
+
+const fs = require('fs');
+const path = require('path');
+const nunjucks = require('nunjucks');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const TEMPLATE_PATH = path.join(
+  REPO_ROOT,
+  'examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml',
+);
+
+const fixturePath = process.argv[2];
+if (!fixturePath) {
+  console.error('Usage: node render.js <fixture.json>');
+  process.exit(2);
+}
+
+const values = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+const templateSource = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+const env = new nunjucks.Environment(null, {
+  autoescape: false,
+  tags: { variableStart: '${{', variableEnd: '}}' },
+});
+env.addFilter('dump', v => JSON.stringify(v));
+
+// The template references `values.X`, so wrap accordingly.
+const rendered = env.renderString(templateSource, { values });
+process.stdout.write(rendered);
+```
+
+- [ ] **Step 2: Create minimal fixture**
+
+Create `scripts/kagent-template/fixtures/minimal.json`:
+
+```json
+{
+  "name": "test-minimal",
+  "description": "Smallest valid kagent agent for contract verification.",
+  "owner": "group:platform-engineering",
+  "systemMessage": "You are a test agent.",
+  "includeBuiltinPrompts": false,
+  "delegateAgents": [],
+  "skills": [],
+  "cpuRequest": "100m",
+  "cpuLimit": "500m",
+  "memoryRequest": "128Mi",
+  "memoryLimit": "512Mi",
+  "compactionInterval": 10,
+  "overlapSize": 2
+}
+```
+
+- [ ] **Step 3: Create full fixture**
+
+Create `scripts/kagent-template/fixtures/full.json`:
+
+```json
+{
+  "name": "test-full",
+  "description": "Coordinates 'release' & deploy: orchestrates other agents.",
+  "owner": "group:platform-engineering",
+  "systemMessage": "You coordinate other agents.",
+  "includeBuiltinPrompts": true,
+  "delegateAgents": ["helm-agent", "git-agent"],
+  "skills": [
+    {
+      "id": "coordinate-release",
+      "name": "Coordinate release",
+      "description": "Orchestrate a multi-step release.",
+      "examples": ["Release version 1.2.3", "Cut a hotfix"],
+      "tags": ["release", "coordination"]
+    }
+  ],
+  "cpuRequest": "200m",
+  "cpuLimit": "1000m",
+  "memoryRequest": "256Mi",
+  "memoryLimit": "1Gi",
+  "compactionInterval": 20,
+  "overlapSize": 4
+}
+```
+
+- [ ] **Step 4: Create the Layer 1 test script**
+
+Create `scripts/kagent-template/test-contract.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Layer 1 test for the kagent-agent v1 annotation contract.
+# Renders each fixture via the offline Nunjucks renderer, then asserts:
+#   1. Output is valid YAML
+#   2. All 7 agents.platform.ai/* annotations are present
+#   3. JSON-valued annotations parse and have the expected shapes
+#   4. a2a-endpoint follows the convention http://<name>.kagent.svc.cluster.local:8080
+#
+# Exit codes: 0 = all pass; 1 = at least one fixture failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+
+REQUIRED_ANNOTATIONS=(
+  "agents.platform.ai/version"
+  "agents.platform.ai/runtime"
+  "agents.platform.ai/description"
+  "agents.platform.ai/a2a-endpoint"
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+JSON_ANNOTATIONS=(
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+fail_count=0
+
+check_fixture() {
+  local fixture="$1"
+  local fixture_name
+  fixture_name="$(basename "$fixture" .json)"
+
+  echo "=== fixture: $fixture_name ==="
+
+  local rendered
+  if ! rendered="$(node "$SCRIPT_DIR/render.js" "$fixture")"; then
+    echo "  FAIL: render returned non-zero"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  if ! echo "$rendered" | yq eval '.' - > /dev/null 2>&1; then
+    echo "  FAIL: rendered output is not valid YAML"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  for ann in "${REQUIRED_ANNOTATIONS[@]}"; do
+    local val
+    val="$(echo "$rendered" | yq eval ".metadata.annotations.\"$ann\"" -)"
+    if [[ "$val" == "null" || -z "$val" ]]; then
+      echo "  FAIL: missing annotation: $ann"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  for ann in "${JSON_ANNOTATIONS[@]}"; do
+    local val
+    val="$(echo "$rendered" | yq eval ".metadata.annotations.\"$ann\"" -)"
+    if ! echo "$val" | jq empty 2>/dev/null; then
+      echo "  FAIL: $ann is not valid JSON: $val"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  local name
+  name="$(jq -r '.name' "$fixture")"
+  local expected_endpoint="http://${name}.kagent.svc.cluster.local:8080"
+  local actual_endpoint
+  actual_endpoint="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/a2a-endpoint"' -)"
+  if [[ "$actual_endpoint" != "$expected_endpoint" ]]; then
+    echo "  FAIL: a2a-endpoint mismatch"
+    echo "    expected: $expected_endpoint"
+    echo "    actual:   $actual_endpoint"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local version
+  version="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/version"' -)"
+  if [[ "$version" != "v1" ]]; then
+    echo "  FAIL: version is not 'v1' (got '$version')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local runtime
+  runtime="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/runtime"' -)"
+  if [[ "$runtime" != "kagent" ]]; then
+    echo "  FAIL: runtime is not 'kagent' (got '$runtime')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local description_in actual_description
+  description_in="$(jq -r '.description' "$fixture" | sed 's/[[:space:]]*$//;s/^[[:space:]]*//')"
+  actual_description="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/description"' -)"
+  if [[ "$actual_description" != "$description_in" ]]; then
+    echo "  FAIL: description round-trip mismatch (YAML-escaping bug?)"
+    echo "    fixture input: $description_in"
+    echo "    rendered:      $actual_description"
+    fail_count=$((fail_count + 1))
+  fi
+
+  echo "  done"
+}
+
+for fixture in "$FIXTURES_DIR"/*.json; do
+  check_fixture "$fixture"
+done
+
+echo
+if [[ $fail_count -eq 0 ]]; then
+  echo "All fixtures passed."
+  exit 0
+else
+  echo "$fail_count failure(s) across fixtures."
+  exit 1
+fi
+```
+
+- [ ] **Step 5: Make the test script executable and run it (expect failures)**
+
+```bash
+chmod +x scripts/kagent-template/test-contract.sh scripts/kagent-template/render.js
+bash scripts/kagent-template/test-contract.sh || true
+```
+
+Expected output: every fixture reports `FAIL: missing annotation: agents.platform.ai/version` (and 6 other missing annotations), exit code 1. This confirms the test catches the missing contract.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/kagent-template/
+git commit -m "test(kagent): add Layer 1 render-contract harness
+
+Offline Nunjucks renderer + fixtures + bash assertions for the
+v1 agent annotation contract. Currently fails against the template
+(no agents.platform.ai/* annotations); will pass after the template
+change in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add the v1 annotation contract to the kagent CRD template
+
+Now make the failing tests pass by adding the 7 annotations to the rendered CRD.
+
+**Files:**
+- Modify: `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml`
+
+- [ ] **Step 1: Add the annotations**
+
+Edit the file. The existing `metadata.annotations` block is at lines 12–16. Insert 7 new annotations after `backstage.io/owner`, **before** the `spec:` block at line 17:
+
+Current state (lines 12–17):
+```yaml
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
+    backstage.io/owner: ${{ values.owner }}
+spec:
+```
+
+New state:
+```yaml
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
+    backstage.io/owner: ${{ values.owner }}
+    # === agents.platform.ai/* v1 contract ===
+    # Structured metadata mirrored to the Backstage catalog by the TeraSky
+    # kubernetes-ingestor. Consumed by future MCP-backed assistants to
+    # enumerate and call this agent. Contract spec:
+    # docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+    agents.platform.ai/version: "v1"
+    agents.platform.ai/runtime: kagent
+    agents.platform.ai/description: |-
+      ${{ values.description | trim }}
+    agents.platform.ai/a2a-endpoint: http://${{ values.name }}.kagent.svc.cluster.local:8080
+    agents.platform.ai/skills: |-
+      ${{ values.skills | dump }}
+    agents.platform.ai/delegates: |-
+      ${{ values.delegateAgents | dump }}
+    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
+spec:
+```
+
+- [ ] **Step 2: Re-run the Layer 1 tests (expect pass)**
+
+```bash
+bash scripts/kagent-template/test-contract.sh
+```
+
+Expected output: `All fixtures passed.`, exit code 0.
+
+- [ ] **Step 3: Inspect a rendered fixture by hand to confirm shape**
+
+```bash
+node scripts/kagent-template/render.js scripts/kagent-template/fixtures/full.json | yq eval '.metadata.annotations' -
+```
+
+Expected: all 7 `agents.platform.ai/*` keys present; `skills` value parses as the full fixture's skills array when fed to `jq`; `delegates` is `["helm-agent","git-agent"]`.
+
+- [ ] **Step 4: Verify the existing example agents in `examples/entities.yaml` still load**
+
+This is a regression smoke check. The change is additive, but confirm the YAML schema still parses:
+
+```bash
+yq eval '.' examples/templates/kagent-agent/content/base-apps/kagent/agents/'${{ values.name }}.yaml' > /dev/null
+echo "exit: $?"
+```
+
+Expected: exit 0 (file parses as YAML even with the Nunjucks placeholders intact, because `yq` treats them as string content).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add 'examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml'
+git commit -m "feat(kagent): emit agents.platform.ai/* v1 contract
+
+Adds 7 structured annotations to the rendered kagent Agent CRD so
+MCP-backed assistants can enumerate and call agents via the
+Backstage catalog API without a second K8s API hop.
+
+Layer 1 contract test (scripts/kagent-template/test-contract.sh)
+now passes. See docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+for the contract definition and migration path to upstream AIContext.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Layer 3 contract reader (post-deployment validation)
+
+Once the template change is merged, ArgoCD syncs, and TeraSky ingests, an operator runs this script to confirm the annotations made it through the K8s → ingestor → catalog round-trip on a real agent.
+
+**Files:**
+- Create: `scripts/check-agent-contract.sh`
+
+- [ ] **Step 1: Create the catalog-query script**
+
+Create `scripts/check-agent-contract.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Layer 3 test: validates that live kagent agents in the Backstage catalog
+# carry the v1 agents.platform.ai/* annotation contract.
+#
+# Usage:
+#   BACKSTAGE_URL=http://localhost:7007 \
+#   BACKSTAGE_TOKEN=<service-token-or-empty> \
+#   bash scripts/check-agent-contract.sh
+#
+# Exit codes: 0 = all live agents conform; 1 = at least one non-conforming.
+
+set -euo pipefail
+
+: "${BACKSTAGE_URL:?BACKSTAGE_URL is required (e.g. http://localhost:7007)}"
+TOKEN="${BACKSTAGE_TOKEN:-}"
+
+AUTH_ARG=()
+if [[ -n "$TOKEN" ]]; then
+  AUTH_ARG=(-H "Authorization: Bearer $TOKEN")
+fi
+
+REQUIRED_ANNOTATIONS=(
+  "agents.platform.ai/version"
+  "agents.platform.ai/runtime"
+  "agents.platform.ai/description"
+  "agents.platform.ai/a2a-endpoint"
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+JSON_ANNOTATIONS=(
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+# Fetch all Component entities with spec.type == kagent-agent.
+entities="$(curl -fsS "${AUTH_ARG[@]}" \
+  "$BACKSTAGE_URL/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent")"
+
+count="$(echo "$entities" | jq 'length')"
+echo "Found $count kagent agent(s) in catalog"
+if [[ "$count" -eq 0 ]]; then
+  echo "Note: no agents to validate. Either none are deployed yet or the ingestor hasn't run."
+  exit 0
+fi
+
+fail_count=0
+
+while IFS= read -r entity_name; do
+  echo "=== $entity_name ==="
+
+  for ann in "${REQUIRED_ANNOTATIONS[@]}"; do
+    val="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"$ann\"] // empty")"
+    if [[ -z "$val" ]]; then
+      echo "  FAIL: missing annotation: $ann"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  for ann in "${JSON_ANNOTATIONS[@]}"; do
+    val="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"$ann\"] // empty")"
+    if [[ -n "$val" ]] && ! echo "$val" | jq empty 2>/dev/null; then
+      echo "  FAIL: $ann is not valid JSON"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  version="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"agents.platform.ai/version\"] // empty")"
+  if [[ "$version" != "v1" ]]; then
+    echo "  FAIL: version is not 'v1' (got '$version')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  echo "  done"
+done < <(echo "$entities" | jq -r '.[].metadata.name')
+
+echo
+if [[ $fail_count -eq 0 ]]; then
+  echo "All $count agent(s) conform to v1 contract."
+  exit 0
+else
+  echo "$fail_count failure(s) across $count agent(s)."
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Make it executable and dry-run against an empty/unavailable catalog**
+
+```bash
+chmod +x scripts/check-agent-contract.sh
+BACKSTAGE_URL=http://localhost:7007 bash scripts/check-agent-contract.sh || true
+```
+
+Expected: either (a) connection refused if dev server isn't running (acceptable — script is for operators with a live server), or (b) "Found 0 kagent agent(s) in catalog" followed by exit 0 if no agents are deployed yet, or (c) per-agent validation output. All three are acceptable outcomes — we're just confirming the script doesn't crash.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/check-agent-contract.sh
+git commit -m "test(kagent): add Layer 3 catalog-API contract reader
+
+Operator-run script that queries the Backstage catalog API for all
+kagent-agent components and validates the v1 agents.platform.ai/*
+contract end-to-end (after K8s -> TeraSky ingestor -> catalog).
+
+Will be the canary for breakage on Backstage or TeraSky upgrades,
+and the seed of the future MCP server's catalog reader.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Documentation
+
+Public-facing contract docs so future MCP authors and scorecard authors can rely on this contract without re-deriving it from source.
+
+**Files:**
+- Create: `docs/guides/agent-annotation-contract-v1.md`
+- Modify: `docs/plans/auto-discovery-contract-implementation-plan.md`
+
+- [ ] **Step 1: Create the contract guide**
+
+Create `docs/guides/agent-annotation-contract-v1.md`:
+
+```markdown
+# Agent Annotation Contract — v1
+
+> Companion to the kagent-agent scaffolder template. Documents the
+> `agents.platform.ai/*` annotations that every IDP-managed kagent
+> Agent carries in both its K8s CRD and its Backstage catalog entity.
+>
+> Design spec: `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`
+
+## Purpose
+
+Make kagent agents queryable as a first-class, structured concept in
+the Backstage catalog so that MCP-backed assistants and scorecard
+checks can read them via the catalog API alone, without a second K8s
+API hop.
+
+## Where the contract lives
+
+- **Source of truth:** `metadata.annotations` on the rendered
+  `kagent.dev/v1alpha2` Agent CRD in `arigsela/kubernetes`.
+- **Catalog mirror:** TeraSky's `kubernetes-ingestor` copies the
+  annotations 1:1 onto the resulting `kind: Component, spec.type: kagent-agent`
+  entity in the Backstage catalog.
+- **Query:** `GET /api/catalog/entities?filter=kind=Component,spec.type=kagent-agent`
+
+## Fields (v1)
+
+| Annotation | Type | Required | Description |
+| --- | --- | --- | --- |
+| `agents.platform.ai/version` | string (`"v1"`) | yes | Contract version. Consumers must reject unknown versions. |
+| `agents.platform.ai/runtime` | string (`kagent`) | yes | Runtime that hosts this agent. Discriminator for future multi-runtime support. |
+| `agents.platform.ai/description` | string | yes | Human-readable one-liner, ≤200 chars. |
+| `agents.platform.ai/a2a-endpoint` | URL | yes | Where to call this agent (A2A protocol). For kagent: `http://<name>.kagent.svc.cluster.local:8080`. |
+| `agents.platform.ai/skills` | JSON array | yes (may be `[]`) | A2A skills: `[{id,name,description,examples?,tags?}, …]` |
+| `agents.platform.ai/delegates` | JSON array of strings | yes (may be `[]`) | Peer agent names this agent is allowed to call. |
+| `agents.platform.ai/capabilities` | JSON object | yes | Capability flags. For kagent v1: `{"streaming":true,"a2a":true}`. |
+
+## Consumers (reader code)
+
+The minimum reader code to enumerate agents from the catalog:
+
+```bash
+curl -s "$BACKSTAGE_URL/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent" \
+  | jq '.[] | {
+      name: .metadata.name,
+      desc: .metadata.annotations["agents.platform.ai/description"],
+      endpoint: .metadata.annotations["agents.platform.ai/a2a-endpoint"],
+      skills: (.metadata.annotations["agents.platform.ai/skills"] | fromjson),
+      delegates: (.metadata.annotations["agents.platform.ai/delegates"] | fromjson)
+    }'
+```
+
+## Validation tools
+
+- **Offline (Layer 1):** `bash scripts/kagent-template/test-contract.sh`
+- **Live catalog (Layer 3):** `BACKSTAGE_URL=… bash scripts/check-agent-contract.sh`
+
+## Forward compatibility
+
+The v1 namespace and shape were chosen to migrate cleanly to the
+upstream `kind: AIContext` proposal (RFC #33575) when it ships. The
+migration path and field mapping are documented in the design spec.
+
+## Future versions
+
+Anticipated v2 additions (not implemented):
+
+- `agents.platform.ai/system-message-digest` — change detection
+- `agents.platform.ai/disciplines` — when MCP routing needs discipline-aware selection
+- `agents.platform.ai/categories` — when group-by-category becomes useful
+
+Adding v2 fields will bump `agents.platform.ai/version` to `"v2"`. Consumers should default-reject unknown versions rather than ignoring fields they don't understand.
+```
+
+- [ ] **Step 2: Add cross-reference to the auto-discovery plan**
+
+Open `docs/plans/auto-discovery-contract-implementation-plan.md`. After the "Overview" section heading and its body paragraph (around lines 1–10), add a short "Related work" block:
+
+```markdown
+## Related work
+
+- **`agents.platform.ai/*` v1 contract** — kagent agents emit a structured annotation contract for MCP and scorecard consumers. See `docs/guides/agent-annotation-contract-v1.md` and the design spec at `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`. This and the auto-discovery contract are intentionally orthogonal: the auto-discovery contract describes how a frontend finds *running* orchestrators via K8s Service labels; the agent annotation contract describes how MCP enumerates *catalog-registered* agents.
+```
+
+(If the file already has a "Related work" section, append to it instead of creating a duplicate.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/guides/agent-annotation-contract-v1.md docs/plans/auto-discovery-contract-implementation-plan.md
+git commit -m "docs(kagent): document agents.platform.ai/* v1 contract
+
+Public-facing guide for MCP authors and scorecard authors who want
+to consume kagent agents from the Backstage catalog. Cross-references
+the design spec and the auto-discovery contract plan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Operator verification checklist (post-merge)
+
+These steps are out of scope for the implementation tasks above —
+they are run by an operator after the PR merges and ArgoCD syncs.
+Listed here so they're not forgotten.
+
+- [ ] Scaffold a new test agent via the Backstage wizard (with
+      `dryRun: false`). Confirm the PR opens in `arigsela/kubernetes`
+      with the new annotations on the Agent CRD.
+- [ ] After merging the GitOps PR, wait ~30s for ArgoCD sync, then
+      wait another ~30s for the TeraSky ingestor's next pass.
+- [ ] Run `BACKSTAGE_URL=… bash scripts/check-agent-contract.sh` and
+      confirm exit code 0.
+- [ ] Optionally clean up the test agent via the
+      `kagent-agent-decommission` template.
+
+---
+
+## Self-review notes
+
+- All 7 contract annotations are added in Task 2 and verified by Task 1's test (which is written first).
+- The renderer in Task 1 is a real, standalone script — no placeholders, no "implement renderer here" stubs.
+- Migration to `AIContext` is referenced for context but explicitly out of scope; no migration tasks are present.
+- The `cluster.local` DNS suffix in `a2a-endpoint` assumes the standard K8s cluster DNS. If your cluster uses a non-standard suffix, adjust both the template and the Layer 1 test assertion.
+- Tasks 1 and 2 must execute in order (Task 1 establishes the failing test that Task 2 makes pass). Tasks 3 and 4 are independent and could be parallelized.

--- a/docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+++ b/docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
@@ -158,7 +158,8 @@ metadata:
     # --- NEW: agent contract v1 ---
     agents.platform.ai/version: "v1"
     agents.platform.ai/runtime: kagent
-    agents.platform.ai/description: ${{ values.description | trim }}
+    agents.platform.ai/description: |-
+      ${{ values.description | trim }}
     agents.platform.ai/a2a-endpoint: http://${{ values.name }}.kagent.svc.cluster.local:8080
     agents.platform.ai/skills: |-
       ${{ values.skills | dump }}
@@ -170,8 +171,11 @@ metadata:
 **Nunjucks/YAML notes:**
 
 - `| dump` produces a JSON string from the input value
-- `|-` block scalar forces YAML to treat the JSON output as a string, not
-  parse it as nested YAML
+- `|-` block scalar is applied to **all user-input-derived string values**
+  (`description`, `skills`, `delegates`) to shield against `:`, newlines,
+  quotes, or any other character that would otherwise be interpreted by
+  the YAML parser. Constant values (`version`, `runtime`, `capabilities`)
+  and the controlled-format `a2a-endpoint` are safe as plain scalars.
 - Empty arrays render as `[]`
 - No new dependencies, no custom scaffolder actions
 

--- a/docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+++ b/docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
@@ -1,0 +1,298 @@
+# AIContext Catalog Modeling for kagent Agents — Design
+
+**Status:** Draft
+**Date:** 2026-05-19
+**Owner:** group:platform-engineering
+**Related:** RFC #33575 (Backstage upstream), `docs/plans/auto-discovery-contract-implementation-plan.md`
+
+## Summary
+
+Make kagent agents queryable as a first-class, structured concept in the
+Backstage catalog so that future MCP-backed AI assistants can discover them and
+call them. RFC #33575 (`kind: AIContext`) is not yet released; this design
+delivers a **structurally equivalent** contract on top of the existing
+`Component` entity using a dedicated `agents.platform.ai/*` annotation
+namespace. Migration to upstream `AIContext` becomes a one-off ingestor
+mapping when the RFC lands.
+
+**Scope:** kagent template only. CrewAI is deferred to a follow-up spec.
+**Primary consumer:** future MCP backend (not built here).
+
+## Goals
+
+- Expose every IDP-managed kagent Agent in the Backstage catalog with enough
+  structured metadata for an MCP server to enumerate them, describe their
+  capabilities, and route calls to their A2A endpoints — **using only the
+  Backstage catalog API**, without a second K8s API hop.
+- Stay on the existing single source of truth (the rendered Agent CRD in
+  `arigsela/kubernetes`); no parallel catalog-info.yaml.
+- Design annotation names that migrate cleanly to upstream `AIContext` fields
+  when RFC #33575 lands.
+
+## Non-goals
+
+- Installing the MCP backend (`@backstage/plugin-mcp-actions-backend`). That
+  is a separate effort that becomes feasible after we upgrade Backstage to
+  v1.49.
+- Modeling CrewAI agents. CrewAI has a different shape (multi-service Python
+  app with an `/info` endpoint and the auto-discovery contract). A follow-up
+  spec will adapt this contract to that shape.
+- Adopting the literal `kind: AIContext`. RFC #33575 is unmerged.
+- Backfilling existing agents in `arigsela/kubernetes`. The new annotations
+  are inert until MCP exists; backfill can happen at MCP rollout time.
+
+## Current state
+
+- Kagent agents are scaffolded into `arigsela/kubernetes:base-apps/kagent/agents/<name>.yaml`.
+- TeraSky's `kubernetes-ingestor` (`onlyIngestAnnotatedResources: true`) reads
+  the rendered CRD's `terasky.backstage.io/add-to-catalog: "true"` and emits a
+  `kind: Component` entity with `spec.type: kagent-agent`.
+- The ingestor mirrors `metadata.annotations` 1:1 to the resulting entity's
+  `metadata.annotations`. It does **not** mirror `spec.*`.
+- Backstage is on v1.48.0. No MCP backend installed.
+
+## Architecture
+
+```
+Scaffolder wizard
+   │
+   ▼
+Renders Agent CRD (kagent.dev/v1alpha2) with:
+   - existing terasky.backstage.io/* annotations
+   - NEW agents.platform.ai/* annotations (the contract)
+   │
+   ▼
+PR opens to arigsela/kubernetes
+   │
+   ▼
+ArgoCD syncs Agent CRD → kagent namespace
+   │
+   ▼
+TeraSky kubernetes-ingestor (runs every 30s) sees
+the add-to-catalog annotation, creates/updates a
+Component entity in the Backstage catalog. Copies
+metadata.annotations 1:1 onto the entity.
+   │
+   ▼
+Backstage catalog now holds:
+   kind: Component
+   spec.type: kagent-agent
+   metadata.annotations:
+     agents.platform.ai/version: "v1"
+     agents.platform.ai/skills: <JSON>
+     agents.platform.ai/delegates: <JSON>
+     ...
+   │
+   ▼
+(Future) MCP backend queries:
+   GET /catalog/entities?filter=kind=Component,spec.type=kagent-agent
+parses the annotations, exposes each agent as a
+callable MCP tool.
+```
+
+**Why annotations, not labels or spec mirroring:**
+
+- TeraSky mirrors `metadata.annotations` but not `spec.*`.
+- K8s label values have a 63-char limit and character restrictions; JSON
+  payloads don't fit.
+- JSON-encoded annotation values are an established Backstage pattern
+  (e.g. `backstage.io/source-location`).
+
+**Why duplicate kagent CRD spec fields into annotations:**
+
+The kagent CRD already carries the structured data in `spec.declarative.*`,
+but Backstage entities only see what the ingestor mirrors. Without
+duplication, MCP would need a second K8s API call per agent — making it
+stateful about K8s and slower. Duplicating into annotations keeps MCP a pure
+catalog-API client.
+
+## The annotation contract (v1)
+
+Namespace: `agents.platform.ai/*`. Added to `metadata.annotations` on the
+rendered Agent CRD, alongside the existing terasky/backstage annotations.
+
+| Annotation | Value | Source | Purpose |
+| --- | --- | --- | --- |
+| `agents.platform.ai/version` | `"v1"` | constant | Contract version for forward-compatibility |
+| `agents.platform.ai/runtime` | `kagent` | constant | Discriminator (future: `crewai`) |
+| `agents.platform.ai/description` | one-line, ≤200 chars | wizard `parameters.description` | Human-readable summary |
+| `agents.platform.ai/a2a-endpoint` | `http://<name>.kagent.svc.cluster.local:8080` | derived from `parameters.name` | Where MCP routes calls |
+| `agents.platform.ai/skills` | JSON array | wizard `parameters.skills` | A2A skills: `[{id,name,description,examples?,tags?}, …]` |
+| `agents.platform.ai/delegates` | JSON array of strings | wizard `parameters.delegateAgents` | Peer agent names this agent can call |
+| `agents.platform.ai/capabilities` | JSON object | constant per runtime | `{"streaming":true,"a2a":true}` for kagent |
+
+### Empty-value conventions
+
+- `skills`: `[]` (never null, never missing)
+- `delegates`: `[]` (never null, never missing)
+- All annotations are always present — MCP can rely on key existence rather
+  than null-checking.
+
+### Out of v1 (and why)
+
+| Field | Rationale for deferral |
+| --- | --- |
+| `system-message-digest` | Would require a custom scaffolder action (Node `crypto`). Git already tracks systemMessage history; no current consumer needs the digest. |
+| `disciplines` / `categories` | Adds wizard friction with no current consumer. Add in v2 if MCP later wants discipline-based routing. |
+| Full `systemMessage` text | Too long for annotations; MCP can read from K8s on demand if it really needs the full text. |
+| `lifecycle` | Handled by standard `spec.lifecycle` on the Component entity via TeraSky's own annotations. |
+| Resource sizes (CPU/memory) | Runtime concern, not catalog concern. |
+
+## Implementation surface
+
+**Files touched: 1.**
+
+### `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml`
+
+Add 7 new annotations under `metadata.annotations` (existing annotations
+unchanged):
+
+```yaml
+metadata:
+  annotations:
+    # --- existing ---
+    terasky.backstage.io/add-to-catalog: "true"
+    terasky.backstage.io/component-type: kagent-agent
+    backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
+    backstage.io/owner: ${{ values.owner }}
+    # --- NEW: agent contract v1 ---
+    agents.platform.ai/version: "v1"
+    agents.platform.ai/runtime: kagent
+    agents.platform.ai/description: ${{ values.description | trim }}
+    agents.platform.ai/a2a-endpoint: http://${{ values.name }}.kagent.svc.cluster.local:8080
+    agents.platform.ai/skills: |-
+      ${{ values.skills | dump }}
+    agents.platform.ai/delegates: |-
+      ${{ values.delegateAgents | dump }}
+    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
+```
+
+**Nunjucks/YAML notes:**
+
+- `| dump` produces a JSON string from the input value
+- `|-` block scalar forces YAML to treat the JSON output as a string, not
+  parse it as nested YAML
+- Empty arrays render as `[]`
+- No new dependencies, no custom scaffolder actions
+
+### `examples/templates/kagent-agent/template.yaml`
+
+**No changes.** All needed data is already collected by the existing wizard
+(`parameters.description`, `parameters.skills`, `parameters.delegateAgents`,
+`parameters.name`).
+
+## Testing strategy
+
+### Layer 1 — Render correctness (no cluster)
+
+Use the existing `dryRun` wizard toggle. Output goes to
+`/tmp/backstage-scaffolder/<name>/base-apps/kagent/agents/<name>.yaml`.
+
+Manual checks (codify in `scripts/` once stable):
+
+- File is valid YAML (`yq eval`)
+- All 7 `agents.platform.ai/*` annotations present
+- `skills`, `delegates`, `capabilities` values parse as JSON
+- `a2a-endpoint` matches `http://<name>.kagent.svc.cluster.local:8080`
+
+Fixture wizard inputs:
+
+- Empty `skills`, empty `delegateAgents` → expect `[]` (not `null`)
+- One skill with `examples` + `tags` → round-trips
+- Two delegate agents → JSON array of strings
+- Description with special chars (`"`, `'`, one line, ≤200 chars)
+
+### Layer 2 — Ingestion correctness (cluster required)
+
+Scaffold a real agent end-to-end. ~30s after ArgoCD sync:
+
+```bash
+curl -s "$BACKSTAGE_URL/api/catalog/entities/by-name/component/default/<name>" \
+  | jq '.metadata.annotations | with_entries(select(.key | startswith("agents.platform.ai/")))'
+```
+
+Assertions:
+
+- All 7 annotations made it through TeraSky's ingestor unchanged
+- JSON values still parse after the K8s → ingestor → catalog round-trip
+- `spec.type == "kagent-agent"` (regression check)
+
+### Layer 3 — Contract validity script
+
+A ~30-line script (TS or Python) that:
+
+1. Queries `/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent`
+2. Parses the 4 JSON-valued annotations per agent
+3. Schema-validates against the v1 contract
+
+This is the canary for breakage on Backstage or TeraSky upgrades, and the
+seed of the future MCP server's catalog reader.
+
+### Out of scope for testing
+
+- Actual MCP behavior (no server installed)
+- kagent runtime behavior at `a2a-endpoint` (kagent's responsibility)
+- AIContext migration (untestable until RFC #33575 ships)
+
+## Error handling
+
+| Failure mode | Mitigation |
+| --- | --- |
+| User submits invalid skill structure | Wizard parameter schema already covers shape; can add `pattern` on skill `id` for tighter validation |
+| JSON breaks YAML parsing at ArgoCD apply | Layer 1 dry-run catches in PR; `|-` block scalar protects |
+| TeraSky strips unknown annotations | If observed at Layer 2, fall back to `terasky.backstage.io/`-prefixed annotation names (TeraSky reliably mirrors its own prefix) |
+| Skills/delegates contain unsafe chars | `dump` escapes per JSON spec; YAML string scalar shields from interpretation |
+| Duplicate agent name | Existing `kagent:agent:validate-name` action handles this |
+
+## Rollout
+
+- **No feature flag.** New annotations are inert until something reads them.
+- **No backfill required.** Existing rendered CRDs keep working; they just
+  lack the new annotations until re-rendered. MCP (when installed) should
+  treat missing annotations as "legacy agent, skip" rather than failing.
+- **Rollback:** revert the single template file. Already-merged agent PRs are
+  unaffected (annotations are harmless metadata).
+
+## AIContext migration (when RFC #33575 ships)
+
+Two-phase migration:
+
+1. **Phase A — Emit `kind: AIContext` entities.** Requires either (a) TeraSky
+   to gain custom-kind support, or (b) a sidecar `catalog-info.yaml` step in
+   the scaffolder. Choice depends on what's available at the time.
+2. **Phase B — Translate existing v1 annotations.** One-off script reads
+   `/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent`, maps
+   each annotation to its AIContext field, writes a migration PR updating the
+   CRDs in place.
+
+### Field mapping (annotation → AIContext)
+
+| v1 annotation | AIContext field |
+| --- | --- |
+| `agents.platform.ai/skills` | `spec.skills` |
+| `agents.platform.ai/delegates` | `spec.agents` (peer refs) |
+| `agents.platform.ai/capabilities` | `spec.allowedTools` (inverse: what this agent uses) |
+| `agents.platform.ai/runtime` | `spec.categories[]` |
+| `agents.platform.ai/description` | `metadata.description` |
+
+`agents.platform.ai/version` and `agents.platform.ai/a2a-endpoint` have no
+direct AIContext equivalent and remain as Backstage annotations on the
+migrated `AIContext` entity (`version` becomes legacy metadata; `a2a-endpoint`
+stays useful for MCP routing regardless of kind).
+
+No data loss path — the v1 annotations preserve every field AIContext needs.
+
+## Documentation updates as part of this work
+
+- Inline comments in `${{ values.name }}.yaml` explaining each new annotation
+- New section in `docs/guides/` documenting the `agents.platform.ai/*`
+  contract for future consumers (MCP authors, scorecard authors)
+- Cross-reference from `docs/plans/auto-discovery-contract-implementation-plan.md`
+
+## Open questions
+
+None blocking. Items for future specs:
+
+- CrewAI adaptation of this contract (separate spec)
+- Whether the v2 contract should add `system-message-digest` once MCP exists
+- Whether `disciplines` belongs in v2 or in `spec.tags` on the Component

--- a/examples/org.yaml
+++ b/examples/org.yaml
@@ -96,3 +96,26 @@ metadata:
 spec:
   type: team
   children: [] # No sub-groups yet
+
+---
+# GROUP: kubernetes-auto-ingested
+# Stub group referenced by entities ingested via TeraSky's kubernetes-ingestor
+# when a K8s resource lacks an explicit owner annotation. Without this stub,
+# Backstage shows "entities not found" warnings on every auto-ingested entity's
+# page (e.g. our kagent agents).
+#
+# This is intentionally NOT a real team — it's a catch-all sink so the catalog
+# graph remains consistent. Real ownership should be set on the K8s resource
+# via `backstage.io/owner` annotation; entities that fall through to this
+# group are a signal that the source manifest is missing ownership metadata.
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: kubernetes-auto-ingested
+  description: >-
+    Synthetic catch-all group for entities auto-ingested from Kubernetes
+    without an explicit owner. Not a real team — assign a real owner via
+    the backstage.io/owner annotation on the source K8s resource.
+spec:
+  type: synthetic # Marker type to distinguish from real teams (team/department/etc.)
+  children: []

--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -14,8 +14,25 @@ metadata:
     terasky.backstage.io/component-type: kagent-agent
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
     backstage.io/owner: ${{ values.owner }}
+    # === agents.platform.ai/* v1 contract ===
+    # Structured metadata mirrored to the Backstage catalog by the TeraSky
+    # kubernetes-ingestor. Consumed by future MCP-backed assistants to
+    # enumerate and call this agent. Contract spec:
+    # docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md
+    agents.platform.ai/version: "v1"
+    agents.platform.ai/runtime: kagent
+    agents.platform.ai/description: |-
+      ${{ values.description | trim | indent(6) }}
+    # Port 8080 is the kagent default A2A service port.
+    agents.platform.ai/a2a-endpoint: http://${{ values.name }}.kagent.svc.cluster.local:8080
+    agents.platform.ai/skills: |-
+      ${{ values.skills | dump }}
+    agents.platform.ai/delegates: |-
+      ${{ values.delegateAgents | dump }}
+    agents.platform.ai/capabilities: '{"streaming":true,"a2a":true}'
 spec:
-  description: ${{ values.description }}
+  description: |-
+    ${{ values.description | trim | indent(4) }}
   type: Declarative
   declarative:
     modelConfig: default-model-config

--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -74,12 +74,16 @@ spec:
 {%- endif %}
 {%- endfor %}
 {%- endif %}
+{%- if values.delegateAgents | length > 0 %}
     tools:
 {%- for agentName in values.delegateAgents %}
     - type: Agent
       agent:
         name: ${{ agentName }}
 {%- endfor %}
+{%- else %}
+    tools: []
+{%- endif %}
     deployment:
       resources:
         requests:

--- a/examples/templates/kagent-agent/template.yaml
+++ b/examples/templates/kagent-agent/template.yaml
@@ -65,7 +65,7 @@ spec:
 
     # --- WIZARD PAGE 2: Behavior ---
     - title: Behavior
-      required: [systemMessage, delegateAgents]
+      required: [systemMessage]
       properties:
         systemMessage:
           title: System message
@@ -91,12 +91,12 @@ spec:
             ConfigMap.
           default: true
         delegateAgents:
-          title: Delegate to these agents
+          title: Delegate to these agents (optional)
           type: array
+          default: []
           description: >-
-            One or more agents this agent can delegate tasks to (A2A protocol).
-            Must select at least one.
-          minItems: 1
+            Agents this agent can delegate tasks to (A2A protocol). Leave
+            empty for a standalone agent that doesn't delegate.
           uniqueItems: true
           items:
             type: string

--- a/scripts/check-agent-contract.sh
+++ b/scripts/check-agent-contract.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Layer 3 test: validates that live kagent agents in the Backstage catalog
+# carry the v1 agents.platform.ai/* annotation contract.
+#
+# Usage:
+#   BACKSTAGE_URL=http://localhost:7007 \
+#   BACKSTAGE_TOKEN=<service-token-or-empty> \
+#   bash scripts/check-agent-contract.sh
+#
+# Exit codes:
+#   0 = all live agents conform
+#   1 = at least one non-conforming agent
+#   2 = infrastructure error (e.g. Backstage API unreachable or returned non-JSON)
+
+set -euo pipefail
+
+: "${BACKSTAGE_URL:?BACKSTAGE_URL is required (e.g. http://localhost:7007)}"
+TOKEN="${BACKSTAGE_TOKEN:-}"
+
+AUTH_ARG=()
+if [[ -n "$TOKEN" ]]; then
+  AUTH_ARG=(-H "Authorization: Bearer $TOKEN")
+fi
+
+REQUIRED_ANNOTATIONS=(
+  "agents.platform.ai/version"
+  "agents.platform.ai/runtime"
+  "agents.platform.ai/description"
+  "agents.platform.ai/a2a-endpoint"
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+JSON_ANNOTATIONS=(
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+# Fetch all Component entities with spec.type == kagent-agent.
+# Note: ${AUTH_ARG[@]+"${AUTH_ARG[@]}"} is the set -u-safe way to expand an
+# array that may be empty (plain ${AUTH_ARG[@]} triggers "unbound variable").
+entities="$(curl -fsS "${AUTH_ARG[@]+"${AUTH_ARG[@]}"}" \
+  "$BACKSTAGE_URL/api/catalog/entities?filter=kind=Component,spec.type=kagent-agent")"
+
+if ! count="$(echo "$entities" | jq 'length' 2>/dev/null)"; then
+  echo "ERROR: Backstage API did not return valid JSON. Check BACKSTAGE_URL and BACKSTAGE_TOKEN." >&2
+  echo "Response body (first 200 chars): ${entities:0:200}" >&2
+  exit 2
+fi
+echo "Found $count kagent agent(s) in catalog"
+if [[ "$count" -eq 0 ]]; then
+  echo "Note: no agents to validate. Either none are deployed yet or the ingestor hasn't run."
+  exit 0
+fi
+
+fail_count=0
+
+while IFS= read -r entity_name; do
+  echo "=== $entity_name ==="
+
+  for ann in "${REQUIRED_ANNOTATIONS[@]}"; do
+    val="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"$ann\"] // empty")"
+    if [[ -z "$val" ]]; then
+      echo "  FAIL: missing annotation: $ann"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  for ann in "${JSON_ANNOTATIONS[@]}"; do
+    val="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"$ann\"] // empty")"
+    if [[ -n "$val" ]] && ! echo "$val" | jq empty 2>/dev/null; then
+      echo "  FAIL: $ann is not valid JSON: $val"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  # Strict v1 check; update when v2 contract is ratified.
+  # The presence-of-version check is covered by REQUIRED_ANNOTATIONS above, so
+  # only flag value mismatch here when the annotation is actually present.
+  version="$(echo "$entities" | jq -r ".[] | select(.metadata.name == \"$entity_name\") | .metadata.annotations[\"agents.platform.ai/version\"] // empty")"
+  if [[ -n "$version" && "$version" != "v1" ]]; then
+    echo "  FAIL: version is not 'v1' (got '$version')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  echo "  done"
+done < <(echo "$entities" | jq -r '.[].metadata.name')
+
+echo
+if [[ $fail_count -eq 0 ]]; then
+  echo "All $count agent(s) conform to v1 contract."
+  exit 0
+else
+  echo "$fail_count failure(s) across $count agent(s)."
+  exit 1
+fi

--- a/scripts/kagent-template/fixtures/full.json
+++ b/scripts/kagent-template/fixtures/full.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-full",
+  "description": "Coordinates 'release' & deploy: orchestrates other agents.",
+  "owner": "group:platform-engineering",
+  "systemMessage": "You coordinate other agents.",
+  "includeBuiltinPrompts": true,
+  "delegateAgents": ["helm-agent", "git-agent"],
+  "skills": [
+    {
+      "id": "coordinate-release",
+      "name": "Coordinate release",
+      "description": "Orchestrate a multi-step release.",
+      "examples": ["Release version 1.2.3", "Cut a hotfix"],
+      "tags": ["release", "coordination"]
+    }
+  ],
+  "cpuRequest": "200m",
+  "cpuLimit": "1000m",
+  "memoryRequest": "256Mi",
+  "memoryLimit": "1Gi",
+  "compactionInterval": 20,
+  "overlapSize": 4
+}

--- a/scripts/kagent-template/fixtures/minimal.json
+++ b/scripts/kagent-template/fixtures/minimal.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-minimal",
+  "description": "Smallest valid kagent agent for contract verification.",
+  "owner": "group:platform-engineering",
+  "systemMessage": "You are a test agent.",
+  "includeBuiltinPrompts": false,
+  "delegateAgents": [],
+  "skills": [],
+  "cpuRequest": "100m",
+  "cpuLimit": "500m",
+  "memoryRequest": "128Mi",
+  "memoryLimit": "512Mi",
+  "compactionInterval": 10,
+  "overlapSize": 2
+}

--- a/scripts/kagent-template/fixtures/multiline.json
+++ b/scripts/kagent-template/fixtures/multiline.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-multiline",
+  "description": "Line one of the description.\nLine two with: a colon.\nLine three.",
+  "owner": "group:platform-engineering",
+  "systemMessage": "You handle multi-paragraph specs.",
+  "includeBuiltinPrompts": false,
+  "delegateAgents": [],
+  "skills": [],
+  "cpuRequest": "100m",
+  "cpuLimit": "500m",
+  "memoryRequest": "128Mi",
+  "memoryLimit": "512Mi",
+  "compactionInterval": 10,
+  "overlapSize": 2
+}

--- a/scripts/kagent-template/render.js
+++ b/scripts/kagent-template/render.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Offline renderer for the kagent-agent scaffolder template.
+// Usage: node render.js <fixture.json> > rendered.yaml
+//
+// Mirrors Backstage scaffolder's Nunjucks setup:
+//   - Custom variable tags: ${{ ... }} (not {{ ... }})
+//   - Custom `dump` filter that JSON-stringifies
+//   - Standard `trim`, `length`, `indent` filters from Nunjucks core
+
+const fs = require('fs');
+const path = require('path');
+const nunjucks = require('nunjucks');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const TEMPLATE_PATH = path.join(
+  REPO_ROOT,
+  'examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml',
+);
+
+const fixturePath = process.argv[2];
+if (!fixturePath) {
+  console.error('Usage: node render.js <fixture.json>');
+  process.exit(2);
+}
+
+const values = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+const templateSource = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+const env = new nunjucks.Environment(null, {
+  autoescape: false,
+  tags: { variableStart: '${{', variableEnd: '}}' },
+});
+env.addFilter('dump', (v, spaces) => JSON.stringify(v, null, spaces));
+
+// The template references `values.X`, so wrap accordingly.
+const rendered = env.renderString(templateSource, { values });
+process.stdout.write(rendered);

--- a/scripts/kagent-template/test-contract.sh
+++ b/scripts/kagent-template/test-contract.sh
@@ -105,6 +105,15 @@ check_fixture() {
     fail_count=$((fail_count + 1))
   fi
 
+  # spec.declarative.tools must always be a list (never null), or the kagent
+  # CRD's OpenAPI validation rejects the resource at apply time.
+  local tools_kind
+  tools_kind="$(echo "$rendered" | yq eval '.spec.declarative.tools | tag' -)"
+  if [[ "$tools_kind" != "!!seq" ]]; then
+    echo "  FAIL: spec.declarative.tools must be a list (got tag '$tools_kind')"
+    fail_count=$((fail_count + 1))
+  fi
+
   echo "  done"
 }
 

--- a/scripts/kagent-template/test-contract.sh
+++ b/scripts/kagent-template/test-contract.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Layer 1 test for the kagent-agent v1 annotation contract.
+# Renders each fixture via the offline Nunjucks renderer, then asserts:
+#   1. Output is valid YAML
+#   2. All 7 agents.platform.ai/* annotations are present
+#   3. JSON-valued annotations parse and have the expected shapes
+#   4. a2a-endpoint follows the convention http://<name>.kagent.svc.cluster.local:8080
+#
+# Exit codes: 0 = all pass; 1 = at least one fixture failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+
+REQUIRED_ANNOTATIONS=(
+  "agents.platform.ai/version"
+  "agents.platform.ai/runtime"
+  "agents.platform.ai/description"
+  "agents.platform.ai/a2a-endpoint"
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+JSON_ANNOTATIONS=(
+  "agents.platform.ai/skills"
+  "agents.platform.ai/delegates"
+  "agents.platform.ai/capabilities"
+)
+
+fail_count=0
+
+check_fixture() {
+  local fixture="$1"
+  local fixture_name
+  fixture_name="$(basename "$fixture" .json)"
+
+  echo "=== fixture: $fixture_name ==="
+
+  local rendered
+  if ! rendered="$(node "$SCRIPT_DIR/render.js" "$fixture")"; then
+    echo "  FAIL: render returned non-zero"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  if ! echo "$rendered" | yq eval '.' - > /dev/null 2>&1; then
+    echo "  FAIL: rendered output is not valid YAML"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  for ann in "${REQUIRED_ANNOTATIONS[@]}"; do
+    local val
+    val="$(echo "$rendered" | yq eval ".metadata.annotations.\"$ann\"" -)"
+    if [[ "$val" == "null" || -z "$val" ]]; then
+      echo "  FAIL: missing annotation: $ann"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  for ann in "${JSON_ANNOTATIONS[@]}"; do
+    local val
+    val="$(echo "$rendered" | yq eval ".metadata.annotations.\"$ann\"" -)"
+    if ! echo "$val" | jq empty 2>/dev/null; then
+      echo "  FAIL: $ann is not valid JSON: $val"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  local name
+  name="$(jq -r '.name' "$fixture")"
+  local expected_endpoint="http://${name}.kagent.svc.cluster.local:8080"
+  local actual_endpoint
+  actual_endpoint="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/a2a-endpoint"' -)"
+  if [[ "$actual_endpoint" != "$expected_endpoint" ]]; then
+    echo "  FAIL: a2a-endpoint mismatch"
+    echo "    expected: $expected_endpoint"
+    echo "    actual:   $actual_endpoint"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local version
+  version="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/version"' -)"
+  if [[ "$version" != "v1" ]]; then
+    echo "  FAIL: version is not 'v1' (got '$version')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local runtime
+  runtime="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/runtime"' -)"
+  if [[ "$runtime" != "kagent" ]]; then
+    echo "  FAIL: runtime is not 'kagent' (got '$runtime')"
+    fail_count=$((fail_count + 1))
+  fi
+
+  local description_in actual_description
+  description_in="$(jq -r '.description' "$fixture" | sed 's/[[:space:]]*$//;s/^[[:space:]]*//')"
+  actual_description="$(echo "$rendered" | yq eval '.metadata.annotations."agents.platform.ai/description"' -)"
+  if [[ "$actual_description" != "$description_in" ]]; then
+    echo "  FAIL: description round-trip mismatch (YAML-escaping bug?)"
+    echo "    fixture input: $description_in"
+    echo "    rendered:      $actual_description"
+    fail_count=$((fail_count + 1))
+  fi
+
+  echo "  done"
+}
+
+for fixture in "$FIXTURES_DIR"/*.json; do
+  check_fixture "$fixture"
+done
+
+echo
+if [[ $fail_count -eq 0 ]]; then
+  echo "All fixtures passed."
+  exit 0
+else
+  echo "$fail_count failure(s) across fixtures."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two related bodies of work shipped together on this branch:

### 1. kagent v1.8 — Kubernetes entity tab
- Adds `kagent.dev/Agent` to `kubernetes.customResources` so the K8s plugin can fetch the live Agent CRD for scaffolded agents
- Adds a Kubernetes tab to the `kagent-agent` entity page surfacing the Agent CRD + workloads
- Renders K8s-discovery labels (`backstage.io/kubernetes-id`) on the scaffolded Agent CRD so the entity-to-resources lookup works
- Migrates the kagent decommission check off the brittle `app.kubernetes.io/managed-by` label onto a dedicated `arigsela.com/idp-managed` label

### 2. `agents.platform.ai/*` v1 annotation contract
A structured annotation contract on every scaffolded kagent Agent CRD that makes agents queryable as a first-class concept via the Backstage catalog API — designed for future MCP-backed AI assistants to enumerate and call agents without a second K8s API hop.

7 new annotations on the rendered Agent CRD (mirrored to the catalog 1:1 by TeraSky's `kubernetes-ingestor`):

| Annotation | Purpose |
|---|---|
| `agents.platform.ai/version` (`"v1"`) | Contract version for forward-compat |
| `agents.platform.ai/runtime` (`kagent`) | Runtime discriminator |
| `agents.platform.ai/description` | Human-readable one-liner |
| `agents.platform.ai/a2a-endpoint` | Where MCP routes calls |
| `agents.platform.ai/skills` (JSON) | A2A skills array |
| `agents.platform.ai/delegates` (JSON) | Peer agents this one delegates to |
| `agents.platform.ai/capabilities` (JSON) | `{"streaming":true,"a2a":true}` |

Plus a bonus fix: `spec.description` on the rendered CRD was using a plain YAML scalar, so a user description containing `:` or newlines would break YAML parsing. Switched to a `|-` block scalar with `| indent(N)` to match the existing `systemMessage` pattern.

### Design and migration story
- Designed to migrate cleanly to upstream `kind: AIContext` (RFC #33575) when it ships — see the design spec for the field mapping
- Single source of truth stays the K8s CRD; no sidecar `catalog-info.yaml`
- Works on Backstage v1.48.0 — no upgrades required

## Documentation
- Design spec: `docs/superpowers/specs/2026-05-19-aicontext-catalog-kind-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-19-aicontext-catalog-kind.md`
- Public contract guide: `docs/guides/agent-annotation-contract-v1.md`
- Capability recommendations covering this and other Backstage 2026 patterns: `docs/guides/backstage-capability-recommendations.md`

## Test plan

- [ ] CI passes
- [ ] Run the Layer 1 offline contract test locally: `bash scripts/kagent-template/test-contract.sh` — expect `All fixtures passed.` (3 fixtures: minimal, full, multiline)
- [ ] Start the dev server, scaffold a new agent via the wizard with `dryRun: true`, inspect the rendered output in `/tmp/backstage-scaffolder/<name>/base-apps/kagent/agents/<name>.yaml`, confirm all 7 `agents.platform.ai/*` annotations are present and well-formed
- [ ] Scaffold an agent for real (PR to `arigsela/kubernetes`), merge, wait for ArgoCD sync + TeraSky ingest, then run the Layer 3 catalog-API contract test: `BACKSTAGE_URL=https://backstage.arigsela.com BACKSTAGE_TOKEN=<optional> bash scripts/check-agent-contract.sh` — expect exit 0 and `All N agent(s) conform to v1 contract.`
- [ ] On the new agent's entity page in Backstage, confirm the Kubernetes tab loads and shows both the Agent CRD and the resulting workloads
- [ ] Test the decommission flow end-to-end on an IDP-managed agent (confirms the new `arigsela.com/idp-managed` label check works)

## Notes for reviewers
- The new annotations are inert until something reads them — MCP backend isn't installed yet (waiting on Backstage 1.49 upgrade for multi-server MCP support). Safe to merge as additive.
- No backfill required for existing agents in `arigsela/kubernetes`; the v1 reader scripts treat missing annotations as "legacy agent, skip" rather than failing.
- Final implementation review surfaced a few non-blocking follow-ups (declare `nunjucks` dep in `scripts/kagent-template/package.json`, add `maxLength: 200` to the wizard description field, hook Layer 1 test into CI). Open as follow-up issues if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)