### PR TITLE
feat(kagent): surface chat link on scaffolded agent entity pages

### DIFF
--- a/docs/superpowers/specs/2026-05-22-kagent-chat-link-design.md
+++ b/docs/superpowers/specs/2026-05-22-kagent-chat-link-design.md
@@ -1,0 +1,106 @@
+# Kagent Chat Link on Backstage Agent Entity — Design
+
+**Date:** 2026-05-22
+**Status:** Approved
+**Author:** Ari Sela (via Claude Code brainstorming)
+
+## Problem
+
+A scaffolded kagent agent appears in Backstage's catalog as a Component entity (e.g.
+`/catalog/default/component/homelab-knowledge`). The entity page renders a Links card,
+but for kagent agents that card currently says "No links defined for this entity."
+
+Each agent has a live chat dashboard at
+`https://kagent.arigsela.com/agents/kagent/<agent-name>/chat`. There is no affordance
+on the Backstage entity page that takes the viewer there — they have to know the
+URL pattern and type it by hand.
+
+## Goal
+
+Newly scaffolded kagent agents should display a "Chat with this agent" link in the
+Backstage entity page's Links card, deep-linking to the kagent chat dashboard for
+that specific agent.
+
+## Non-Goals
+
+- Retrofitting the ~7 existing agents in `arigsela/kubernetes` (`homelab-knowledge`,
+  `k8s-agent`, `helm-agent`, `istio-agent`, `kgateway-agent`,
+  `argo-rollouts-conversion-agent`, `observability-agent`). They keep showing
+  "No links defined" until manually edited.
+- Adding any other links (agent overview page, GitHub source, etc.).
+- Making the kagent base URL configurable per environment.
+
+## Mechanism
+
+The TeraSky `kubernetes-ingestor` already supports a `terasky.backstage.io/links`
+annotation. Implementation reference:
+`node_modules/@terasky/backstage-plugin-kubernetes-ingestor/dist/providers/EntityProvider.cjs.js:3248`.
+
+The ingestor:
+
+1. Reads the annotation value as a string.
+2. `JSON.parse`s it — expects an array of `{ url, title, icon, type }` objects.
+3. Emits each entry as `metadata.links[]` on the Backstage catalog entity.
+
+So no plugin code is needed — just inject the annotation in the rendered Agent CRD.
+
+## Change
+
+One annotation added to the rendered template at
+`examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml`,
+in the existing `annotations:` block alongside the other `terasky.backstage.io/*`
+annotations:
+
+```yaml
+terasky.backstage.io/links: '[{"url":"https://kagent.arigsela.com/agents/kagent/${{ values.name }}/chat","title":"Chat with this agent","icon":"chat"}]'
+```
+
+### Why this specific shape
+
+- **Single-quoted YAML scalar.** No backslash escaping. The only YAML escape required
+  inside a single-quoted scalar is doubling embedded single quotes — none of which
+  appear in this value.
+- **Compact JSON on one line.** The ingestor calls `JSON.parse` on the string; both
+  pretty-printed and compact JSON are equivalent. Compact keeps the diff readable
+  in PRs to the kubernetes repo.
+- **Nunjucks substitutes `${{ values.name }}` at scaffold time.** The YAML committed
+  to the repo contains the literal agent name in the URL — the ingestor never sees
+  Nunjucks syntax.
+- **Icon `chat`.** Member of Backstage's default registered icon set, so it renders
+  without additional frontend configuration.
+
+### Safety: JSON injection
+
+Agent names are validated by the existing wizard regex
+`^[a-z][a-z0-9-]{2,38}[a-z0-9]$` (lowercase letters, digits, hyphens only). None of
+those characters require JSON escaping, so substituting `${{ values.name }}` into
+the JSON-encoded annotation cannot produce malformed JSON.
+
+## End-to-End Flow
+
+1. User scaffolds a new agent via the Kagent Declarative Agent template.
+2. Scaffolder renders the CRD YAML with the literal annotation baked in and opens
+   a PR against `arigsela/kubernetes`.
+3. PR merges → ArgoCD's `kagent-secrets` app applies the Agent CRD.
+4. TeraSky `kubernetes-ingestor` re-scans on its 30s cadence
+   (`kubernetesIngestor.components.taskRunner.frequency: 30` in `app-config.yaml`),
+   reads the annotation, parses it, emits `metadata.links` on the catalog entity.
+5. The agent's entity page Links card renders "Chat with this agent" linking to
+   `https://kagent.arigsela.com/agents/kagent/<name>/chat`.
+
+## Testing
+
+Use the template's existing dry-run mode (`dryRun: true` on the Publish page).
+Output is written to `/tmp/backstage-scaffolder/<name>/`; inspecting the rendered
+`base-apps/kagent/agents/<name>.yaml` should show the annotation with the substituted
+name. Full end-to-end verification requires a real run, merging the kubernetes PR,
+and waiting one ingestor cycle (≤ 30s).
+
+## Risks / Open Issues
+
+- **Ingestor strips unknown annotations** (documented mitigation in the agent
+  annotation contract). The `terasky.backstage.io/*` prefix is the ingestor's own
+  namespace and is reliably mirrored, so this annotation is not at risk.
+- **Existing agents not retrofitted.** Intentional per scope decision. Side effect:
+  inconsistent UX between agents created before and after this change until the
+  existing seven are manually updated.

--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     terasky.backstage.io/add-to-catalog: "true"
     terasky.backstage.io/component-type: kagent-agent
+    terasky.backstage.io/links: '[{"url":"https://kagent.arigsela.com/agents/kagent/${{ values.name }}/chat","title":"Chat with this agent","icon":"chat"}]'
     backstage.io/managed-by-location: url:https://github.com/arigsela/kubernetes/blob/main/base-apps/kagent/agents/${{ values.name }}.yaml
     backstage.io/owner: ${{ values.owner }}
     # === agents.platform.ai/* v1 contract ===


### PR DESCRIPTION
## Summary
- Newly scaffolded kagent agents now show a **Chat with this agent** link in the Backstage entity page's Links card, deep-linking to `https://kagent.arigsela.com/agents/kagent/<name>/chat`.
- Implemented via the existing `terasky.backstage.io/links` annotation supported by the TeraSky `kubernetes-ingestor` — no plugin code changes needed.
- One-line addition to the rendered Agent CRD template; verified by parsing the rendered YAML and the JSON inside the annotation against a sample agent name.

## Changes

### Template
- `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml` — added `terasky.backstage.io/links` annotation alongside the existing `terasky.backstage.io/*` annotations. Scaffolder substitutes `${{ values.name }}` at render time, so the YAML committed to `arigsela/kubernetes` contains a literal URL.

### Spec
- `docs/superpowers/specs/2026-05-22-kagent-chat-link-design.md` — full design doc covering mechanism, end-to-end flow, testing, and risks.

### Mechanism
The TeraSky `kubernetes-ingestor` (`node_modules/@terasky/backstage-plugin-kubernetes-ingestor/dist/providers/EntityProvider.cjs.js:3248`) JSON-parses any `terasky.backstage.io/links` annotation it finds on an ingested resource and emits the entries as `metadata.links[]` on the resulting catalog entity. The Backstage entity page's Links card renders these natively.

### End-to-End Flow
1. User scaffolds a new agent via the Kagent Declarative Agent template.
2. Scaffolder opens a PR against `arigsela/kubernetes` with the literal URL baked in.
3. PR merges → ArgoCD applies the Agent CRD.
4. TeraSky ingestor re-scans on its 30s cadence, reads the annotation, emits `metadata.links` on the catalog entity.
5. Agent's entity page shows the clickable chat link.

## Test Plan
- [x] Dry-substitution test: rendered YAML parses, annotation JSON parses, URL/title/icon all correct for sample name `release-coordinator`.
- [ ] End-to-end after merge: scaffold a new test agent via the template's `dryRun: true` mode and confirm the rendered annotation has the expected substituted name.
- [ ] Full E2E: real scaffold → merge kubernetes PR → wait one ingestor cycle (≤30s) → confirm Links card on the agent's catalog page shows "Chat with this agent".

## Scope / Non-Goals
- **Existing agents are out of scope.** The seven agents already in `arigsela/kubernetes` (`homelab-knowledge`, `k8s-agent`, `helm-agent`, `istio-agent`, `kgateway-agent`, `argo-rollouts-conversion-agent`, `observability-agent`) will continue to show "No links defined" until manually edited.
- Only the chat link is added. No agent overview link or GitHub source link.
- Kagent base URL is hardcoded to `https://kagent.arigsela.com`, matching the existing pattern in this template (the GitHub source URL is also hardcoded).

## Safety: JSON Injection
Agent names are validated by the existing wizard regex `^[a-z][a-z0-9-]{2,38}[a-z0-9]$` (lowercase letters, digits, hyphens only). None of those characters require JSON escaping, so substituting `${{ values.name }}` into the JSON-encoded annotation cannot produce malformed JSON.

## Related
- Spec: `docs/superpowers/specs/2026-05-22-kagent-chat-link-design.md`
- Kagent agent template: `examples/templates/kagent-agent/template.yaml`
- Agent annotation contract v1: `docs/guides/agent-annotation-contract-v1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)