### PR TITLE
fix(kagent): always emit tags on rendered Agent skills

### DIFF
--- a/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
+++ b/examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml
@@ -72,6 +72,8 @@ spec:
 {%- for tag in skill.tags %}
         - ${{ tag }}
 {%- endfor %}
+{%- else %}
+        tags: []
 {%- endif %}
 {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
## Summary
- Render `tags: []` whenever a skill has no tags, so the field is always present on `spec.declarative.a2aConfig.skills[]`
- Unblocks Agent creation through the `kagent-agent` scaffolder template after the kagent v1.8 / CRD chart `0.8.6` upgrade
- Two-line change, no behavior change for skills that already carry tags

## Problem
The kagent CRD chart `0.8.6` marks `tags` as **required** on each `spec.declarative.a2aConfig.skills[]` entry:

```yaml
required:
- id
- name
- tags
```

The content template emitted `tags:` only when the user supplied at least one tag:

```yaml
{%- if skill.tags and skill.tags | length > 0 %}
        tags:
{%- for tag in skill.tags %}
        - ${{ tag }}
{%- endfor %}
{%- endif %}
```

Skills added through the new `KagentSuggest` AI-assist field (introduced in #25) never carry tags — the LLM prompt and `itemShape` ask only for `id`, `name`, `description`. So the rendered Agent CR omitted `tags` entirely on those skills and ArgoCD's sync failed with:

```
Agent.kagent.dev "dungeoncrawler-crawl-agent" is invalid:
[spec.declarative.a2aConfig.skills[0].tags: Required value,
 spec.declarative.a2aConfig.skills[1].tags: Required value,
 spec.declarative.a2aConfig.skills[2].tags: Required value, ...]
```

## Changes
### Template Update
- `examples/templates/kagent-agent/content/base-apps/kagent/agents/${{ values.name }}.yaml` — added an `else` branch that emits `tags: []` when no tags are supplied.

### Why an empty array is safe
The CRD's `tags` schema has no `minItems` constraint:

```yaml
tags:
  description: Tags are optional tags for categorization.
  items:
    type: string
  type: array
```

so `tags: []` satisfies the validator while preserving the "tags optional from the user's POV" UX.

## Test Plan
- [x] Diff is exactly 2 lines (`+{%- else %}` / `+        tags: []`)
- [x] Skills with real tags still render unchanged (else branch only fires when `skill.tags` is empty/missing)
- [ ] Re-scaffold an agent through the wizard using AI assist; confirm ArgoCD syncs the resulting Agent CR cleanly
- [ ] Existing `homelab-knowledge` (and other tagged agents) still render with their populated tags

## Related
- Regression introduced by #25 (`feat/kagent-v1.8-k8s-tab`) — specifically commit `abcf098` (wiring KagentSuggest, which doesn't capture tags) combined with the kagent CRD chart `0.8.6` requiring tags
- Existing Agent CRs in `arigsela/kubernetes` that were created via AI-assist (e.g. `dungeoncrawler-crawl-agent`) will not be patched in this PR — re-scaffold them after merge

## Follow-ups (out of scope)
- Optionally enhance `KagentSuggest` to also capture tags (prompt update + `itemShape` extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)