### PR TITLE
feat(catalog): discover base-apps/*/catalog-info.yaml from kubernetes repo

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -299,6 +299,20 @@ catalog:
           frequency: { minutes: 30 }       # How often to scan for new/updated repos
           timeout: { minutes: 3 }          # Max time for a single scan run
 
+      # Agent-docs framework: the framework places a catalog-info.yaml in each
+      # base-apps/<app>/ directory of the kubernetes repo. The 'arigsela' provider
+      # above only scans repo-root /catalog-info.yaml, so those per-app files were
+      # invisible. This dedicated provider discovers them. Scoped to the one repo
+      # that has base-apps/ so it never scans that path in other repos.
+      arigsela-kubernetes:
+        organization: 'arigsela'
+        catalogPath: '/base-apps/*/catalog-info.yaml'
+        filters:
+          repository: '^kubernetes$'
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+
 # --- KUBERNETES ---
 # The Kubernetes plugin shows pod/deployment status directly on entity pages.
 # Entities with the `backstage.io/kubernetes-id` annotation get a "Kubernetes" tab


### PR DESCRIPTION
Add a dedicated GithubEntityProvider (arigsela-kubernetes) scoped to the
kubernetes repo and the base-apps/* path so the agent-docs framework's per-app
catalog-info.yaml files are ingested into the catalog. The existing org-wide
root provider (arigsela) is unchanged. Config-only; the github catalog module
is already installed and catalog.rules already allow Component and Resource.

Validated: config:check --lax clean, tsc clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
