### PR TITLE
fix(mcp): correct mcpActions catalog server config (name + filter.include)

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -338,8 +338,10 @@ catalog:
 mcpActions:
   servers:
     catalog:
-      include:
-        - id: 'catalog:entity'
+      name: catalog
+      filter:
+        include:
+          - id: 'catalog:entity'
 
 # --- KUBERNETES ---
 # The Kubernetes plugin shows pod/deployment status directly on entity pages.


### PR DESCRIPTION
mcp-actions 0.1.14 requires servers.<key>.name and nests the action filter under
filter.include (my original config put include at the top level and omitted name,
which crashed startup on 1.52: "Missing required config value at
mcpActions.servers.catalog.name"). Now correctly exposes only catalog:entity.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
