### PR TITLE
fix(mcp): use Backstage 1.52 catalog action ids (get/query-catalog-entities)

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -340,8 +340,12 @@ mcpActions:
     catalog:
       name: catalog
       filter:
+        # Read-only catalog actions (Backstage 1.52 ids). get-catalog-entity
+        # returns an entity + its resolved relations; query-catalog-entities
+        # lists/filters entities. NOT register/unregister/validate (mutations).
         include:
-          - id: 'catalog:entity'
+          - id: 'catalog:get-catalog-entity'
+          - id: 'catalog:query-catalog-entities'
 
 # --- KUBERNETES ---
 # The Kubernetes plugin shows pod/deployment status directly on entity pages.


### PR DESCRIPTION
The 1.52 catalog registers read actions as get-catalog-entity and
query-catalog-entities (not the old catalog:entity), so the previous filter
matched nothing and the MCP server exposed 0 tools. Expose both read actions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
