### PR TITLE
fix(mcp): filter catalog server by catalog:* minus mutations

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -340,12 +340,14 @@ mcpActions:
     catalog:
       name: catalog
       filter:
-        # Read-only catalog actions (Backstage 1.52 ids). get-catalog-entity
-        # returns an entity + its resolved relations; query-catalog-entities
-        # lists/filters entities. NOT register/unregister/validate (mutations).
+        # Include all catalog actions, then exclude the mutations — keeps the
+        # server read-only while being robust to the exact action-id spelling.
         include:
-          - id: 'catalog:get-catalog-entity'
-          - id: 'catalog:query-catalog-entities'
+          - id: 'catalog:*'
+        exclude:
+          - id: 'catalog:register-entity'
+          - id: 'catalog:unregister-entity'
+          - id: 'catalog:validate-entity'
 
 # --- KUBERNETES ---
 # The Kubernetes plugin shows pod/deployment status directly on entity pages.


### PR DESCRIPTION
Robust to exact action-id spelling: include catalog:* and exclude the three
mutation actions (register/unregister/validate), leaving the read actions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
