### PR TITLE
fix(mcp): load catalog actions via backend.actions.pluginSources

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -33,6 +33,14 @@ organization:
 # --- BACKEND ---
 # Configuration for the Backstage backend server.
 backend:
+  # ACTIONS SERVICE (alpha): the default actions service only loads actions from
+  # the plugins listed here. Without 'catalog', the catalog's registered actions
+  # (get-catalog-entity, query-catalog-entities) are dropped and the MCP catalog
+  # server exposes 0 tools. Required for the homelab-knowledge agent's MCP tool.
+  actions:
+    pluginSources:
+      - catalog
+
   # SERVICE-TO-SERVICE AUTH:
   # Backstage v1.x's new backend system requires backend plugins to authenticate
   # to each other when making internal API calls. With permission.enabled=true


### PR DESCRIPTION
The default actions service only loads actions from plugins listed in
backend.actions.pluginSources. Without 'catalog', the catalog's registered
actions were dropped and the MCP catalog server exposed 0 tools. Add catalog
so get-catalog-entity/query-catalog-entities reach the MCP server.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
