### PR TITLE
fix(mcp): disable namespaced tool names (dots break Anthropic tool names)

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -344,6 +344,11 @@ catalog:
 # mutations). Consumed by the homelab-knowledge kagent agent for ownership/
 # dependency/system questions. Auth: static token (backend.auth.externalAccess).
 mcpActions:
+  # Do NOT prefix tool names with the plugin id. Default names like
+  # "catalog.get-catalog-entity" contain a dot, which violates Anthropic's tool
+  # name pattern ^[a-zA-Z0-9_-]{1,128}$ and 400s the agent. Undotted names
+  # (e.g. "get-catalog-entity") are valid. Safe here — only catalog is exposed.
+  namespacedToolNames: false
   servers:
     catalog:
       name: catalog


### PR DESCRIPTION
Default tool names are <pluginId>.<action> (e.g. catalog.get-catalog-entity);
the dot violates Anthropic's tool-name pattern ^[a-zA-Z0-9_-]{1,128}$ and 400s
the agent. namespacedToolNames: false yields get-catalog-entity (valid). Only
catalog is exposed, so no collision risk.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNPgcVuVhwbXSQnyzU38d1
