### PR TITLE
feat(catalog): load taxonomy in prod + admit Domain/User + ingest API entities

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -102,6 +102,11 @@ catalog:
       rules:
         - allow: [Group, System, Domain, User]
 
+    - type: url
+      target: https://github.com/arigsela/kubernetes/blob/main/catalog/api-entities.yaml
+      rules:
+        - allow: [API]
+
     # Example entities — demo data bundled in the image (see Dockerfile).
     # In the Docker container, examples/ is at /app/examples/.
     - type: file

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -94,6 +94,14 @@ catalog:
     - type: file
       target: ./catalog-info.yaml
 
+    # Platform taxonomy (Group + Systems + Domains + User) from the kubernetes
+    # repo. Production redefines catalog.locations and arrays REPLACE (not merge),
+    # so this MUST be restated here or the taxonomy never loads in production.
+    - type: url
+      target: https://github.com/arigsela/kubernetes/blob/main/catalog/platform-entities.yaml
+      rules:
+        - allow: [Group, System, Domain, User]
+
     # Example entities — demo data bundled in the image (see Dockerfile).
     # In the Docker container, examples/ is at /app/examples/.
     - type: file

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -242,7 +242,7 @@ catalog:
     - type: url
       target: https://github.com/arigsela/kubernetes/blob/main/catalog/platform-entities.yaml
       rules:
-        - allow: [Group, System]
+        - allow: [Group, System, Domain, User]
 
     # Example entities: a System, Component, and API (see examples/entities.yaml)
     - type: file

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -246,9 +246,9 @@ catalog:
     - type: file
       target: ../../catalog-info.yaml
 
-    # Platform taxonomy (Group + Systems) from the kubernetes repo, giving the
-    # base-apps/* Resources/Components resolvable owner/system relations. Group
-    # is not in the global catalog.rules allow-list, so this location admits it.
+    # Platform taxonomy (Group + Systems + Domains + User) from the kubernetes repo,
+    # giving the base-apps/* Resources/Components resolvable owner/system relations.
+    # Group is not in the global catalog.rules allow-list, so this location admits it.
     - type: url
       target: https://github.com/arigsela/kubernetes/blob/main/catalog/platform-entities.yaml
       rules:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -86,6 +86,16 @@ backend:
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true # Allow cookies/auth headers in cross-origin requests
 
+  # URL-reader allow-list for the $text-fetched API specs (catalog/api-entities.yaml).
+  # The reader rejects any host not listed here. Internal svc URLs => no auth/CORS.
+  # Only in this base config: production inherits it (backend object deep-merges;
+  # prod does not override backend.reading).
+  reading:
+    allow:
+      - host: chores-tracker-backend.chores-tracker.svc.cluster.local
+      - host: weather-kitchen-backend.weather-kitchen.svc.cluster.local
+      - host: dex.dex.svc.cluster.local:5556
+
   # DATABASE:
   # Backstage uses Knex.js under the hood for database access. Each backend
   # plugin gets its own database schema, created automatically on first startup.
@@ -243,6 +253,14 @@ catalog:
       target: https://github.com/arigsela/kubernetes/blob/main/catalog/platform-entities.yaml
       rules:
         - allow: [Group, System, Domain, User]
+
+    # Platform API entities (kind: API) from the kubernetes repo. Not under
+    # base-apps/, so discovered via this dedicated url location rather than the
+    # base-apps discovery provider.
+    - type: url
+      target: https://github.com/arigsela/kubernetes/blob/main/catalog/api-entities.yaml
+      rules:
+        - allow: [API]
 
     # Example entities: a System, Component, and API (see examples/entities.yaml)
     - type: file


### PR DESCRIPTION
## What

Backstage-image half of the catalog-enrichment roadmap (Phases 0–1).

- **Phase 0 — taxonomy loads in prod + admits Domain/User.** `app-config.production.yaml` redefined `catalog.locations` without the `platform-entities.yaml` url location — and Backstage config **arrays replace across layers** (not merge), so the platform taxonomy never loaded in production. Added the location there, and widened its rule `allow: [Group, System]` → `[Group, System, Domain, User]` so the new Domains/User aren't rejected.
- **Phase 1 — ingest API entities + allow-list `$text` hosts.** Registered `catalog/api-entities.yaml` as a url location in **both** config files (arrays replace), and added `backend.reading.allow` (base config only — prod inherits via object merge) for the three in-cluster service hosts the API specs are `$text`-fetched from.

## Pairs with

`arigsela/kubernetes` PR `backstage-catalog-enrichment` — defines the taxonomy `Domain`/`User` entities and `catalog/api-entities.yaml`.

## Validation

`yarn backstage-cli config:check --lax` → clean (schema-valid, including `reading.allow` and both new url locations).

## Deploy note

Config-only — takes effect after a new `backstage-portal` image build + tag bump in the kubernetes repo's `base-apps/backstage/deployments.yaml`. The Domains/User/APIs appear in the portal on that deploy, not at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b
