### PR TITLE
feat(techdocs): install mkdocs + local generator (Phase 4)

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -160,7 +160,7 @@ proxy:
 techdocs:
   builder: 'local'
   generator:
-    runIn: 'docker' # 'docker' runs mkdocs inside a container, 'local' needs mkdocs installed
+    runIn: 'local' # in-process mkdocs (installed in the image); avoids Docker-in-Docker in the pod
   publisher:
     type: 'local'
 

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -55,6 +55,32 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -y --no-install-recommends libsqlite3-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# TECHDOCS (local generator):
+# With `techdocs.generator.runIn: 'local'` in app-config, Backstage builds each
+# entity's docs in-process by shelling out to `mkdocs` — no Docker-in-Docker.
+# That needs mkdocs + the TechDocs plugin bundle on PATH. python3 is already
+# present (installed above for node-gyp); this adds pip + mkdocs-techdocs-core,
+# putting `mkdocs` on /usr/local/bin (on PATH for the `node` user). Installed as
+# root before the USER switch below.
+#
+# WHY get-pip + --no-compile (not `apt-get install python3-pip`):
+# This image is built for linux/amd64 under QEMU emulation on an arm64 host.
+# Debian's python3-pip apt postinst byte-compiles the Python stdlib/site-packages
+# via py3compile, which SEGFAULTS under that emulation (dpkg exit 139). Avoid it
+# by bootstrapping pip with get-pip.py and installing WITHOUT byte-compilation
+# (--no-compile); the real amd64 runtime compiles .pyc lazily on first import.
+# --break-system-packages: Debian trixie marks the system env externally-managed
+# (PEP 668); fine for this single-purpose image.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
+    python3 /tmp/get-pip.py --break-system-packages --no-compile && \
+    rm /tmp/get-pip.py && \
+    pip3 install --break-system-packages --no-cache-dir --no-compile mkdocs-techdocs-core
+
 # SECURITY: Run as non-root user.
 # The `node` user (uid 1000) comes pre-created in the Node.js base image.
 # All subsequent operations run as this unprivileged user.


### PR DESCRIPTION
## What

**Phase 4 (TechDocs) — image side.** Makes the Backstage backend able to build per-entity docs in-process.

- **`packages/backend/Dockerfile`** — install `mkdocs-techdocs-core` so the local generator can shell out to `mkdocs`.
- **`app-config.yaml`** — `techdocs.generator.runIn: 'docker'` → `'local'` (no Docker-in-Docker in the pod). Production inherits the `techdocs` block (object merge), so no restatement needed.

## Why `get-pip.py --no-compile` (not `apt-get install python3-pip`)

This image is built for **linux/amd64 under QEMU emulation** on an arm64 host. Debian's `python3-pip` apt postinst byte-compiles the stdlib via `py3compile`, which **segfaults under that emulation** (dpkg exit 139 — reproduced). Bootstrapping pip with `get-pip.py` and installing with `--no-compile` skips build-time byte-compilation; the real amd64 runtime compiles `.pyc` lazily on first import. `mkdocs` lands on `/usr/local/bin` (on PATH for the `node` user), installed as root before the USER switch.

## Pairs with

`arigsela/kubernetes` PR (`techdocs-phase4`) — per-app `mkdocs.yml`/`docs/` scaffolding + the deployment bump to v1.4.7. **Merge both together.**

## Status

Image already built for **linux/amd64** and pushed: `backstage-portal:v1.4.7` (digest `sha256:d64372903b31a9f7dd1c648498619905faa74ffec3750525c74f85dfd37cc711`). The kubernetes PR's deployment bump references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxovp1bSYJgVSJ4nU5E1b
